### PR TITLE
[feat] 메인 페이지 디자인 수정 및 스터디 목록 호출 기능

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.0.1",
     "@tanstack/react-query": "^5.66.0",
+    "axios": "^1.7.9",
     "daisyui": "^4.12.23",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
@@ -40,5 +41,8 @@
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.18.2",
     "vite": "^6.0.5"
+  },
+  "resolutions": {
+    "rollup": "4.15.0"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-import { BrowserRouter } from 'react-router-dom';
 import './App.css';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter } from 'react-router-dom';

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,14 @@
+import { Link } from 'react-router-dom';
+import Logo from '../assets/logo.png';
+import Bell from '@/assets/icons/bell.svg';
+
+export default function Header() {
+  return (
+    <header className="w-[100%] h-[52px] z-[999] fixed top-0 left-0 px-4 flex items-center justify-between">
+      <Link to={'/'} aria-label="홈으로">
+        <img src={Logo} alt="Logo" className="w-[83px] h-[33px]" />
+      </Link>
+      <Bell />
+    </header>
+  );
+}

--- a/src/layouts/Layout.tsx
+++ b/src/layouts/Layout.tsx
@@ -1,12 +1,18 @@
-import { Outlet } from 'react-router-dom';
+import { Outlet, useLocation } from 'react-router-dom';
+import Header from '../components/Header';
 
 export default function Layout() {
+  const location = useLocation();
+  const url = location.pathname;
+
   return (
     <main
       className="w-full min-h-screen pt-[52px] max-w-3xl mx-auto flex flex-col justify-between relative
     after:content-[''] after:h-[calc(100%-52px)] after:bg-white-gray after:w-[1px] after:absolute after:left-0 after:bottom-0 before:content-[''] before:h-[calc(100%-52px)] before:bg-white-gray before:w-[1px] before:absolute before:right-0 before:bottom-0"
     >
-      <Outlet />
+      {url === '/' && <Header />}
+      {url === 'my-page' && <Header />}
+      <Outlet key={url} />
     </main>
   );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,16 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
+import { createRoot } from 'react-dom/client';
+import App from './App.tsx';
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-)
+async function deferRender() {
+  // if (process.env.NODE_ENV !== 'development') return;
+
+  const { worker } = await import('./mocks/browser.ts');
+
+  return worker.start({
+    onUnhandledRequest: 'bypass',
+  });
+}
+
+deferRender().then(() => {
+  createRoot(document.getElementById('root')!).render(<App />);
+});

--- a/src/mocks/MockData.ts
+++ b/src/mocks/MockData.ts
@@ -1,0 +1,33 @@
+export const mockStudyRoomList: {
+  study_id: number;
+  study_name: string;
+  category: string;
+  leader_id: number;
+  max_members: number;
+  current_members: number;
+}[] = [
+  {
+    study_id: 101,
+    study_name: '코딩 마스터 스터디',
+    category: '코딩',
+    leader_id: 1,
+    max_members: 10,
+    current_members: 5,
+  },
+  {
+    study_id: 102,
+    study_name: '토익 900+ 목표 스터디',
+    category: '어학',
+    leader_id: 2,
+    max_members: 10,
+    current_members: 4,
+  },
+  {
+    study_id: 103,
+    study_name: '토익 800+ 목표 스터디',
+    category: '어학',
+    leader_id: 3,
+    max_members: 8,
+    current_members: 4,
+  },
+];

--- a/src/mocks/browser.ts
+++ b/src/mocks/browser.ts
@@ -1,0 +1,4 @@
+import { setupWorker } from 'msw/browser';
+import { handlers } from './handlers';
+
+export const worker = setupWorker(...handlers);

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,0 +1,3 @@
+import { studyRoomHandlers } from './studyRoomHandlers';
+
+export const handlers = [...studyRoomHandlers];

--- a/src/mocks/studyRoomHandlers.ts
+++ b/src/mocks/studyRoomHandlers.ts
@@ -1,0 +1,70 @@
+/**
+  스터디룸 생성, post, /api/study-room
+	{
+	"status": "OK",
+	"code": 200,
+	"message": "스터디룸이 생성되었습니다.",
+	"result": {
+		"study_id": 101
+		}
+	}
+
+	특정 스터디룸 상세 조회, get, /api/study-room/{study_id}
+	{
+		"status": "OK",
+		"code": 200,
+		"message": "스터디룸의 상세 정보가 조회 되었습니다.",
+		"result": {
+			"study_id": 101,
+			"study_name": "코딩 마스터 스터디",
+			"study_description": "알고리즘 및 코딩 테스트 대비 스터디",
+			"tags": "코딩, 알고리즘",
+			"category": "코딩",
+			"study_notice": "매주 수요일 8시 스터디 진행",
+			"end_date": "2025-12-31",
+			"goal_time": 10,
+			"goal_cycle": "WEEKLY",
+			"penalty_point": 10,
+			"entry_point": 50,
+			"max_members": 10,
+			"current_members": 5,
+			"use_yn": "Y"
+		}
+	}
+
+	스터디룸 수정, put, /api/study-room/{study_id}
+	{
+	"status": "OK",
+	"code": 200,
+	"message": "스터디룸 정보가 수정되었습니다.",
+	"result": {
+		"study_id": 101
+		}
+	}
+
+	스터디룸 삭제, delete, /api/study-room/{study_id}
+	{
+	"status": "OK",
+	"code": 200,
+	"message": "스터디룸이 삭제되었습니다."
+	}
+
+ */
+
+import { http, HttpResponse } from 'msw';
+import { mockStudyRoomList } from './MockData';
+
+export const studyRoomHandlers = [
+  // 스터디룸 목록 조회
+  http.get(`/api/study-room`, async ({ request }) => {
+    console.log('스터디 목록 조회');
+    return HttpResponse.json({
+      status: 'OK',
+      code: 200,
+      message: '스터디 목록이 조회 되었습니다.',
+      result: {
+        study_rooms: mockStudyRoomList,
+      },
+    });
+  }),
+];

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,98 +1,99 @@
-import React from 'react';
-import Logo from '../assets/logo.png';
-import Bell from '@/assets/icons/bell.svg';
-import HomeIcon from '@/assets/icons/home.svg';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
+import { useRef, useEffect } from 'react';
+import axios from 'axios';
 
-const Home = React.memo((): JSX.Element => {
+const fetchStudies = async (pageParam = 1) => {
+  const { data } = await axios.get(`/api/study-room?page=${pageParam}`);
+  return data.result.study_rooms;
+};
+
+export default function Home() {
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery({
+    queryKey: ['study-rooms'],
+    queryFn: ({ pageParam = 1 }) => fetchStudies(pageParam),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage, allPages) => {
+      return lastPage.hasMore ? allPages.length + 1 : undefined;
+    },
+  });
+
+  const observerRef = useRef(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) {
+          fetchNextPage();
+        }
+      },
+      { threshold: 1.0 },
+    );
+    if (observerRef.current) {
+      observer.observe(observerRef.current);
+    }
+    return () => {
+      if (observerRef.current) {
+        observer.unobserve(observerRef.current);
+      }
+    };
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+
+  console.log(data?.pages);
+
   return (
-    <div className="h-[100vh]">
-      <div className="w-full px-4">
-        {/* Header */}
-        <div className="w-[343px] h-[50px] flex items-center justify-between">
-          <img src={Logo} alt="Logo" className="w-[83px] h-[33px]" />
-          <Bell />
+    <div className="h-[100vh] px-4">
+      <Link to={'/search'}>
+        <input
+          className="w-full h-[23px] sm:h-[30px] md:h-[40px] mb-3 border rounded-[10px] border-main text-black text-sm placeholder:pl-2"
+          type="text"
+          placeholder="검색어를 입력하세요."
+        />
+      </Link>
+
+      <div className="w-full h-[24px] mb-3 flex items-center gap-[5px] overflow-y-auto scrollbar-hide">
+        <div className="px-[8px] py-[3px] rounded-[10px] text-sm bg-white-gray flex-shrink-0 whitespace-nowrap min-w-max">
+          # 코딩 X
         </div>
-
-        {/* 검색 창 */}
-        <Link to={'#'}>
-          <input
-            className="w-[343px] h-[23px] mb-3 border rounded-[10px] border-main text-black text-sm placeholder:pl-2"
-            type="text"
-            placeholder="검색어를 입력하세요."
-          />
-        </Link>
-
-        {/* 필터 */}
-        <div className="w-[343px] h-[24px] mb-3 flex items-center gap-[5px] overflow-y-auto scrollbar-hide">
-          <div className="px-[8px] py-[3px] rounded-[10px] text-sm bg-white-gray flex-shrink-0 whitespace-nowrap min-w-max">
-            # 코딩 x
-          </div>
-          <div className="px-[8px] py-[5px] rounded-[10px] text-sm bg-white-gray flex-shrink-0 whitespace-nowrap min-w-max">
-            # 10 ~ 40시간 x
-          </div>
-          <div className="px-[8px] py-[5px] rounded-[10px] text-sm bg-white-gray flex-shrink-0 whitespace-nowrap min-w-max">
-            # 10 ~ 40시간 x
-          </div>
-          <div className="px-[8px] py-[5px] rounded-[10px] text-sm bg-white-gray flex-shrink-0 whitespace-nowrap min-w-max">
-            # 10 ~ 40시간 x
-          </div>
-          <div className="px-[8px] py-[5px] rounded-[10px] text-sm bg-white-gray flex-shrink-0 whitespace-nowrap min-w-max">
-            # 10 ~ 40시간 x
-          </div>
-          <div className="px-[8px] py-[5px] rounded-[10px] text-sm bg-white-gray flex-shrink-0 whitespace-nowrap min-w-max">
-            # 10 ~ 40시간 x
-          </div>
+        <div className="px-[8px] py-[5px] rounded-[10px] text-sm bg-white-gray flex-shrink-0 whitespace-nowrap min-w-max">
+          # 10 ~ 40시간 X
         </div>
+      </div>
 
-        {/* 생성하기 버튼 - 로그인 시 보여줌 없으면 공백*/}
-        <Link
-          to={'/study/create'}
-          className=" h-[30px] mb-3 float-right px-3 py-1 bg-main text-white text-center rounded-[10px]"
-        >
-          <span className="text-sm">+ 스터디 만들기</span>
-        </Link>
-
-        {/* 스터디 목록 */}
-        <div className="w-[343px] h-[400px] mb-3 flex flex-col items-center gap-[5px] overflow-y-scroll scrollbar-hide">
-          {/* 없으면 -> 등록된 스터디가 없습니다. */}
-          {Array.from({ length: 5 }).map((_, index) => (
-            <div key={index} className="w-full bg-white p-3 rounded-[10px] border border-white-gray">
+      {/* 스터디 목록 */}
+      <div className="w-full h-[400px] mt-3 flex flex-col items-center gap-[5px] overflow-y-scroll scrollbar-hide">
+        {data?.pages
+          .flatMap((page) => page)
+          .map((study) => (
+            <div key={study.study_id} className="w-full bg-white p-3 rounded-[10px] border border-white-gray">
               <div className="mb-2">
-                <p className="font-bold">스터디 제목</p>
-                <p className="text-sm text-gray">스터디원 10명</p>
+                <p className="font-bold">{study.study_name}</p>
+                <p className="text-sm text-gray">
+                  스터디원 {study.current_members}명 / {study.max_members}명
+                </p>
               </div>
               <div className="text-sm text-gray">
-                <p>스터디 기간: 2025-01-01 ~ 2025-02-01 (4주)</p>
-                <p>주당 목표 시간: 40시간</p>
-                <p>참여 포인트: 500</p>
+                <p>
+                  스터디 기간: {study.startDate} ~ {study.endDate}
+                </p>
+                <p>주당 목표 시간: {study.weeklyGoal}시간</p>
+                <p>참여 포인트: {study.points}</p>
               </div>
               <div className="flex gap-2 mt-2">
-                <p className="text-xs bg-white-gray px-2 py-1 rounded-md"># 태그</p>
-                <p className="text-xs bg-white-gray px-2 py-1 rounded-md"># 태그</p>
-                <p className="text-xs bg-white-gray px-2 py-1 rounded-md"># 태그</p>
+                <p className="text-xs bg-white-gray px-2 py-1 rounded-md">#{study.category}</p>
               </div>
             </div>
           ))}
-        </div>
+        <div ref={observerRef} className="h-10" />
       </div>
-      {/* nav */}
-      <div className="w-full h-[55px] fixed bottom-0 left-0 flex items-center justify-around bg-white">
-        <Link to={'/'} className="flex flex-col items-center justify-center text-main">
-          <HomeIcon />
-          <p>홈</p>
-        </Link>
-        <Link to={'/'} className="flex flex-col items-center justify-center text-center text-gray">
-          <HomeIcon />
-          <p>그룹</p>
-        </Link>
-        <Link to={'/'} className="flex flex-col items-center justify-center text-center text-gray">
-          <HomeIcon />
-          <p>마이</p>
-        </Link>
-      </div>
+
+      {/* 생성하기 버튼 - 로그인 시 보여줌 없으면 공백*/}
+      <Link
+        to={'/create-study'}
+        className="h-[30px] sm:h-[40px] md:h-[50px] flex items-center justify-center px-3 py-1 bg-main text-white text-center rounded-[10px]"
+      >
+        <span className="text-sm">+ 스터디 만들기</span>
+      </Link>
     </div>
   );
-});
-
-export default Home;
+}

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+
+export default function Search() {
+  const [studyTimeRange, setStudyTimeRange] = useState([0, 0]);
+  const [pointsRange, setPointsRange] = useState([1000, 50000]);
+  const categories = ['코딩', '공무원', '대학 입시', '어학', '취업', '입용', '시험', '기타'];
+
+  return (
+    <div className="p-4 bg-white min-h-screen">
+      <div className="mt-4 relative">
+        <input placeholder="검색어를 입력하세요." className="w-full border-gray-300" />
+        <div className="absolute right-4 top-2 text-gray-500">🔍</div>
+      </div>
+
+      <div className="mt-6">
+        <h2 className="text-sm font-semibold">주당 공부 시간</h2>
+        <div className="flex items-center gap-2 mt-2">
+          <span>매주</span>
+          <div className="flex gap-2">
+            <input
+              type="number"
+              className="w-16 text-center border-gray-300"
+              value={studyTimeRange[0]}
+              onChange={(e) => setStudyTimeRange([Number(e.target.value), studyTimeRange[1]])}
+            />
+            ~
+            <input
+              type="number"
+              className="w-16 text-center border-gray-300"
+              value={studyTimeRange[1]}
+              onChange={(e) => setStudyTimeRange([studyTimeRange[0], Number(e.target.value)])}
+            />
+            <span>시간</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-6">
+        <h2 className="text-sm font-semibold">카테고리</h2>
+        <div className="grid grid-cols-4 gap-2 mt-2">
+          {categories.map((category) => (
+            <label key={category} className="flex items-center gap-1">
+              <input type="radio" name="category" value={category} />
+              <span>{category}</span>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-6">
+        <h2 className="text-sm font-semibold">참여 포인트</h2>
+        <div className="mt-4">
+          <input type="range" min={1000} max={50000} step={1000} className="w-full" />
+          <div className="flex justify-between text-sm mt-2">
+            <span>{pointsRange[0].toLocaleString()}</span>
+            <span>{pointsRange[1].toLocaleString()}</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-8">
+        <button className="w-full bg-sub text-black rounded-xl py-3">검색하기</button>
+      </div>
+    </div>
+  );
+}

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -11,6 +11,7 @@ const Points = lazy(() => import('../pages/Points'));
 const Study = lazy(() => import('../pages/Study'));
 const EditStudy = lazy(() => import('../pages/EditStudy'));
 const Group = lazy(() => import('../pages/Group'));
+const Search = lazy(() => import('../pages/Search'));
 
 const Router = (): JSX.Element => {
   return (
@@ -26,6 +27,7 @@ const Router = (): JSX.Element => {
           <Route path="/points" element={<Points />} />
           <Route path="/study" element={<Study />} />
           <Route path="/edit-study/:studyId" element={<EditStudy />} />
+          <Route path="/search" element={<Search />} />
         </Route>
       </Routes>
     </Suspense>

--- a/yarn.lock
+++ b/yarn.lock
@@ -523,100 +523,85 @@
     estree-walker "^2.0.2"
     picomatch "^4.0.2"
 
-"@rollup/rollup-android-arm-eabi@4.32.1":
-  version "4.32.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.32.1.tgz#c18bad635ba24220a6c8cc427ab2cab12e1531a3"
-  integrity sha512-/pqA4DmqyCm8u5YIDzIdlLcEmuvxb0v8fZdFhVMszSpDTgbQKdw3/mB3eMUHIbubtJ6F9j+LtmyCnHTEqIHyzA==
+"@rollup/rollup-android-arm-eabi@4.15.0":
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.15.0.tgz#28c9c79c5baccb59a96afcf60e428ea6965a5579"
+  integrity sha512-O63bJ7p909pRRQfOJ0k/Jp8gNFMud+ZzLLG5EBWquylHxmRT2k18M2ifg8WyjCgFVdpA7+rI0YZ8EkAtg6dSUw==
 
-"@rollup/rollup-android-arm64@4.32.1":
-  version "4.32.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.32.1.tgz#b5c00344b80f20889b72bfe65d3c209cef247362"
-  integrity sha512-If3PDskT77q7zgqVqYuj7WG3WC08G1kwXGVFi9Jr8nY6eHucREHkfpX79c0ACAjLj3QIWKPJR7w4i+f5EdLH5Q==
+"@rollup/rollup-android-arm64@4.15.0":
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.15.0.tgz#a2bdafdb753ece571956289a5ba8c37af748bd0c"
+  integrity sha512-5UywPdmC9jiVOShjQx4uuIcnTQOf85iA4jgg8bkFoH5NYWFfAfrJpv5eeokmTdSmYwUTT5IrcrBCJNkowhrZDA==
 
-"@rollup/rollup-darwin-arm64@4.32.1":
-  version "4.32.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.32.1.tgz#78e5358d4a2a08c090f75dd87fa2eada42eca1e5"
-  integrity sha512-zCpKHioQ9KgZToFp5Wvz6zaWbMzYQ2LJHQ+QixDKq52KKrF65ueu6Af4hLlLWHjX1Wf/0G5kSJM9PySW9IrvHA==
+"@rollup/rollup-darwin-arm64@4.15.0":
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.15.0.tgz#4cb44cfec3068f6f76f70463ccc25f3e245af06a"
+  integrity sha512-hNkt75uFfWpRxHItCBmbS0ba70WnibJh6yz60WShSWITLlVRbkvAu1E/c7RlliPY4ajhqJd0UPZz//gNalTd4g==
 
-"@rollup/rollup-darwin-x64@4.32.1":
-  version "4.32.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.32.1.tgz#c04c9e173244d44de50278f3f893fb68d987fcc6"
-  integrity sha512-sFvF+t2+TyUo/ZQqUcifrJIgznx58oFZbdHS9TvHq3xhPVL9nOp+yZ6LKrO9GWTP+6DbFtoyLDbjTpR62Mbr3Q==
+"@rollup/rollup-darwin-x64@4.15.0":
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.15.0.tgz#1035bfbf53e6acf16771191f41c3d3aff089e8f1"
+  integrity sha512-HnC5bTP7qdfO9nUw/mBhNcjOEZfbS8NwV+nFegiMhYOn1ATAGZF4kfAxR9BuZevBrebWCxMmxm8NCU1CUoz+wQ==
 
-"@rollup/rollup-freebsd-arm64@4.32.1":
-  version "4.32.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.32.1.tgz#3bdf18d4ef32dcfe9b20bba18d7a53a101ed79d9"
-  integrity sha512-NbOa+7InvMWRcY9RG+B6kKIMD/FsnQPH0MWUvDlQB1iXnF/UcKSudCXZtv4lW+C276g3w5AxPbfry5rSYvyeYA==
+"@rollup/rollup-linux-arm-gnueabihf@4.15.0":
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.15.0.tgz#0036b835f17ca9e84c188c419399493bd5739986"
+  integrity sha512-QGOIQIJZeIIqMsc4BUGe8TnV4dkXhSW2EhaQ1G4LqMUNpkyeLztvlDlOoNHn7SR7a4dBANdcEbPkkEzz3rzjzA==
 
-"@rollup/rollup-freebsd-x64@4.32.1":
-  version "4.32.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.32.1.tgz#35867b15c276f4b4ca8eb226f7dd6df8c64640db"
-  integrity sha512-JRBRmwvHPXR881j2xjry8HZ86wIPK2CcDw0EXchE1UgU0ubWp9nvlT7cZYKc6bkypBt745b4bglf3+xJ7hXWWw==
+"@rollup/rollup-linux-arm-musleabihf@4.15.0":
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.15.0.tgz#c44420167203400ba7a707f8205413c2817cdaeb"
+  integrity sha512-PS/Cp8CinYgoysQ8i4UXYH/TZl06fXszvY/RDkyBYgUB1+tKyOMS925/4FZhfrhkl3XQEKjMc3BKtsxpB9Tz9Q==
 
-"@rollup/rollup-linux-arm-gnueabihf@4.32.1":
-  version "4.32.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.32.1.tgz#92c212d1b38c105bd1eb101254722d27d869b1ac"
-  integrity sha512-PKvszb+9o/vVdUzCCjL0sKHukEQV39tD3fepXxYrHE3sTKrRdCydI7uldRLbjLmDA3TFDmh418XH19NOsDRH8g==
+"@rollup/rollup-linux-arm64-gnu@4.15.0":
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.15.0.tgz#531d3792e1526583ecd794ceee0ab980d79813dd"
+  integrity sha512-XzOsnD6lGDP+k+vGgTYAryVGu8N89qpjMN5BVFUj75dGVFP3FzIVAufJAraxirpDwEQZA7Gjs0Vo5p4UmnnjsA==
 
-"@rollup/rollup-linux-arm-musleabihf@4.32.1":
-  version "4.32.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.32.1.tgz#ebb94d8cd438f23e38caa4a87ca80d4cf5b50fa1"
-  integrity sha512-9WHEMV6Y89eL606ReYowXuGF1Yb2vwfKWKdD1A5h+OYnPZSJvxbEjxTRKPgi7tkP2DSnW0YLab1ooy+i/FQp/Q==
+"@rollup/rollup-linux-arm64-musl@4.15.0":
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.15.0.tgz#86376eaa6d65a860a046e0dfe285a51792bc2026"
+  integrity sha512-+ScJA4Epbx/ZQGjDnbvTAcb8ZD06b+TlIka2UkujbKf1I/A+yrvEcJwG3/27zMmvcWMQyeCJhbL9TlSjzL0B7Q==
 
-"@rollup/rollup-linux-arm64-gnu@4.32.1":
-  version "4.32.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.32.1.tgz#ce6a5eacbd5fd4bdf7bf27bd818980230bdb9fab"
-  integrity sha512-tZWc9iEt5fGJ1CL2LRPw8OttkCBDs+D8D3oEM8mH8S1ICZCtFJhD7DZ3XMGM8kpqHvhGUTvNUYVDnmkj4BDXnw==
+"@rollup/rollup-linux-powerpc64le-gnu@4.15.0":
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.15.0.tgz#6adf69ce27d1266dbb86eeac237ad5dd4d4a1f28"
+  integrity sha512-1cUSvYgnyTakM4FDyf/GxUCDcqmj/hUh1NOizEOJU7+D5xEfFGCxgcNOs3hYBeRMUCcGmGkt01EhD3ILgKpGHQ==
 
-"@rollup/rollup-linux-arm64-musl@4.32.1":
-  version "4.32.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.32.1.tgz#31b4e0a543607e6eb4f982ffb45830919a952a83"
-  integrity sha512-FTYc2YoTWUsBz5GTTgGkRYYJ5NGJIi/rCY4oK/I8aKowx1ToXeoVVbIE4LGAjsauvlhjfl0MYacxClLld1VrOw==
+"@rollup/rollup-linux-riscv64-gnu@4.15.0":
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.15.0.tgz#961c290372d170f588ebf65c145c485c4aad7005"
+  integrity sha512-3A1FbHDbBUvpJXFAZwVsiROIcstVHP9AX/cwnyIhAp+xyQ1cBCxywKtuzmw0Av1MDNNg/y/9dDHtNypfRa8bdw==
 
-"@rollup/rollup-linux-loongarch64-gnu@4.32.1":
-  version "4.32.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.32.1.tgz#ad7b35f193f1d2e0dc37eba733069b4af5f6498d"
-  integrity sha512-F51qLdOtpS6P1zJVRzYM0v6MrBNypyPEN1GfMiz0gPu9jN8ScGaEFIZQwteSsGKg799oR5EaP7+B2jHgL+d+Kw==
+"@rollup/rollup-linux-s390x-gnu@4.15.0":
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.15.0.tgz#cb43301e10f17f0a642416c5d3d82a26cf430fa8"
+  integrity sha512-hYPbhg9ow6/mXIkojc8LOeiip2sCTuw1taWyoOXTOWk9vawIXz8x7B4KkgWUAtvAElssxhSyEXr2EZycH/FGzQ==
 
-"@rollup/rollup-linux-powerpc64le-gnu@4.32.1":
-  version "4.32.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.32.1.tgz#b713a55d7eac4d2c8a0109c3daca6ea85fc178b3"
-  integrity sha512-wO0WkfSppfX4YFm5KhdCCpnpGbtgQNj/tgvYzrVYFKDpven8w2N6Gg5nB6w+wAMO3AIfSTWeTjfVe+uZ23zAlg==
+"@rollup/rollup-linux-x64-gnu@4.15.0":
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.15.0.tgz#25c1fb87b2255949ee7ff6956e205710c5d7c414"
+  integrity sha512-511qln5mPSUKwv7HI28S1jCD1FK+2WbX5THM9A9annr3c1kzmfnf8Oe3ZakubEjob3IV6OPnNNcesfy+adIrmw==
 
-"@rollup/rollup-linux-riscv64-gnu@4.32.1":
-  version "4.32.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.32.1.tgz#bea4fd8ad190e9bc1d11efafa2efc9d121f50b96"
-  integrity sha512-iWswS9cIXfJO1MFYtI/4jjlrGb/V58oMu4dYJIKnR5UIwbkzR0PJ09O0PDZT0oJ3LYWXBSWahNf/Mjo6i1E5/g==
+"@rollup/rollup-linux-x64-musl@4.15.0":
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.15.0.tgz#145745e339e282c7afc36142bd5a3f9495c7c681"
+  integrity sha512-4qKKGTDIv2bQZ+afhPWqPL+94+dLtk4lw1iwbcylKlLNqQ/Yyjof2CFYBxf6npiDzPV+zf4EWRiHb26/4Vsm9w==
 
-"@rollup/rollup-linux-s390x-gnu@4.32.1":
-  version "4.32.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.32.1.tgz#cc98c32733ca472635759c78a79b5f8d887b2a6a"
-  integrity sha512-RKt8NI9tebzmEthMnfVgG3i/XeECkMPS+ibVZjZ6mNekpbbUmkNWuIN2yHsb/mBPyZke4nlI4YqIdFPgKuoyQQ==
+"@rollup/rollup-win32-arm64-msvc@4.15.0":
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.15.0.tgz#95dae687b645a25aab3a082d987556f58274ffbe"
+  integrity sha512-nEtaFBHp1OnbOf+tz66DtID579sNRHGgMC23to8HUyVuOCpCMD0CvRNqiDGLErLNnwApWIUtUl1VvuovCWUxwg==
 
-"@rollup/rollup-linux-x64-gnu@4.32.1":
-  version "4.32.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.32.1.tgz#5c009c264a7ce0e19b40890ca9945440bb420691"
-  integrity sha512-WQFLZ9c42ECqEjwg/GHHsouij3pzLXkFdz0UxHa/0OM12LzvX7DzedlY0SIEly2v18YZLRhCRoHZDxbBSWoGYg==
+"@rollup/rollup-win32-ia32-msvc@4.15.0":
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.15.0.tgz#acbd48f10093e6cd52f99ad004966433a49cb362"
+  integrity sha512-5O49NykwSgX6iT2HgZ6cAoGHt6T/FqNMB5OqFOGxU/y1GyFSHquox1sK2OqApQc0ANxiHFQEMNDLNVCL7AUDnQ==
 
-"@rollup/rollup-linux-x64-musl@4.32.1":
-  version "4.32.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.32.1.tgz#73d2f44070c23e031262b601927fdb4eec253bc1"
-  integrity sha512-BLoiyHDOWoS3uccNSADMza6V6vCNiphi94tQlVIL5de+r6r/CCQuNnerf+1g2mnk2b6edp5dk0nhdZ7aEjOBsA==
-
-"@rollup/rollup-win32-arm64-msvc@4.32.1":
-  version "4.32.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.32.1.tgz#fa106304818078f9d3fc9005642ad99f596eed2d"
-  integrity sha512-w2l3UnlgYTNNU+Z6wOR8YdaioqfEnwPjIsJ66KxKAf0p+AuL2FHeTX6qvM+p/Ue3XPBVNyVSfCrfZiQh7vZHLQ==
-
-"@rollup/rollup-win32-ia32-msvc@4.32.1":
-  version "4.32.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.32.1.tgz#a1a394c705a0d2a974a124c4b471fc1cf851a56f"
-  integrity sha512-Am9H+TGLomPGkBnaPWie4F3x+yQ2rr4Bk2jpwy+iV+Gel9jLAu/KqT8k3X4jxFPW6Zf8OMnehyutsd+eHoq1WQ==
-
-"@rollup/rollup-win32-x64-msvc@4.32.1":
-  version "4.32.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.32.1.tgz#512db088df67afee8f07183cdf8c9eecd64f6ef8"
-  integrity sha512-ar80GhdZb4DgmW3myIS9nRFYcpJRSME8iqWgzH2i44u+IdrzmiXVxeFnExQ5v4JYUSpg94bWjevMG8JHf1Da5Q==
+"@rollup/rollup-win32-x64-msvc@4.15.0":
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.15.0.tgz#68bb584231dfc8e36bb7ad5317dfd1fd2563a6f7"
+  integrity sha512-YA0hTwCunmKNeTOFWdJuKhdXse9jBqgo34FDo+9aS0spfCkp+wj0o1bCcOOTu+0P48O95GTfkLTAaVonwNuIdQ==
 
 "@rtsao/scc@^1.1.0":
   version "1.1.0"
@@ -847,7 +832,12 @@
   resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.6.0.tgz#eac397f28bf1d6ae0ae081363eca2f425bedf0d5"
   integrity sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==
 
-"@types/estree@1.0.6", "@types/estree@^1.0.0", "@types/estree@^1.0.6":
+"@types/estree@1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.5.tgz#a6ce3e556e00fd9895dd872dd172ad0d4bd687f4"
+  integrity sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==
+
+"@types/estree@^1.0.0", "@types/estree@^1.0.6":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.6.tgz#628effeeae2064a1b4e79f78e81d87b7e5fc7b50"
   integrity sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==
@@ -1106,6 +1096,11 @@ async-function@^1.0.0:
   resolved "https://registry.yarnpkg.com/async-function/-/async-function-1.0.0.tgz#509c9fca60eaf85034c6829838188e4e4c8ffb2b"
   integrity sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 autoprefixer@^10.4.20:
   version "10.4.20"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.4.20.tgz#5caec14d43976ef42e32dcb4bd62878e96be5b3b"
@@ -1129,6 +1124,15 @@ axe-core@^4.10.0:
   version "4.10.2"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.10.2.tgz#85228e3e1d8b8532a27659b332e39b7fa0e022df"
   integrity sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==
+
+axios@^1.7.9:
+  version "1.7.9"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.9.tgz#d7d071380c132a24accda1b2cfc1535b79ec650a"
+  integrity sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 axobject-query@^4.1.0:
   version "4.1.0"
@@ -1251,6 +1255,13 @@ color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -1392,6 +1403,11 @@ define-properties@^1.2.1:
     define-data-property "^1.0.1"
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 detect-libc@^1.0.3:
   version "1.0.3"
@@ -1844,12 +1860,26 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.2.tgz#adba1448a9841bec72b42c532ea23dbbedef1a27"
   integrity sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==
 
+follow-redirects@^1.15.6:
+  version "1.15.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
+  integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
+
 for-each@^0.3.3:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.4.tgz#814517ffc303d1399b2564d8165318e735d0341c"
   integrity sha512-kKaIINnFpzW6ffJNDjjyjrk21BkDx38c0xa/klsT8VzLCaMEefv4ZTacrcVR4DmgTeBra++jMDAfS/tS799YDw==
   dependencies:
     is-callable "^1.2.7"
+
+form-data@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.1.tgz#ba1076daaaa5bfd7e99c1a6cb02aa0a5cff90d48"
+  integrity sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 fraction.js@^4.3.7:
   version "4.3.7"
@@ -2468,6 +2498,18 @@ micromatch@^4.0.8:
     braces "^3.0.3"
     picomatch "^2.3.1"
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
 minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
@@ -2733,6 +2775,11 @@ prettier@^3.4.2:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.4.2.tgz#a5ce1fb522a588bf2b78ca44c6e6fe5aa5a2b13f"
   integrity sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==
 
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
 psl@^1.1.33:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.15.0.tgz#bdace31896f1d97cec6a79e8224898ce93d974c6"
@@ -2844,32 +2891,29 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-rollup@^4.23.0:
-  version "4.32.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.32.1.tgz#95309604d92c3d21cbf06c3ee46a098209ce13a4"
-  integrity sha512-z+aeEsOeEa3mEbS1Tjl6sAZ8NE3+AalQz1RJGj81M+fizusbdDMoEJwdJNHfaB40Scr4qNu+welOfes7maKonA==
+rollup@4.15.0, rollup@^4.23.0:
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.15.0.tgz#3be428e4fe86297b1b3448f29515d978593d9d9a"
+  integrity sha512-i0ir57IMF5o7YvNYyUNeIGG+IZaaucnGZAOsSctO2tPLXlCEaZzyBa+QhpHNSgtpyLMoDev2DyN6a7J1dQA8Tw==
   dependencies:
-    "@types/estree" "1.0.6"
+    "@types/estree" "1.0.5"
   optionalDependencies:
-    "@rollup/rollup-android-arm-eabi" "4.32.1"
-    "@rollup/rollup-android-arm64" "4.32.1"
-    "@rollup/rollup-darwin-arm64" "4.32.1"
-    "@rollup/rollup-darwin-x64" "4.32.1"
-    "@rollup/rollup-freebsd-arm64" "4.32.1"
-    "@rollup/rollup-freebsd-x64" "4.32.1"
-    "@rollup/rollup-linux-arm-gnueabihf" "4.32.1"
-    "@rollup/rollup-linux-arm-musleabihf" "4.32.1"
-    "@rollup/rollup-linux-arm64-gnu" "4.32.1"
-    "@rollup/rollup-linux-arm64-musl" "4.32.1"
-    "@rollup/rollup-linux-loongarch64-gnu" "4.32.1"
-    "@rollup/rollup-linux-powerpc64le-gnu" "4.32.1"
-    "@rollup/rollup-linux-riscv64-gnu" "4.32.1"
-    "@rollup/rollup-linux-s390x-gnu" "4.32.1"
-    "@rollup/rollup-linux-x64-gnu" "4.32.1"
-    "@rollup/rollup-linux-x64-musl" "4.32.1"
-    "@rollup/rollup-win32-arm64-msvc" "4.32.1"
-    "@rollup/rollup-win32-ia32-msvc" "4.32.1"
-    "@rollup/rollup-win32-x64-msvc" "4.32.1"
+    "@rollup/rollup-android-arm-eabi" "4.15.0"
+    "@rollup/rollup-android-arm64" "4.15.0"
+    "@rollup/rollup-darwin-arm64" "4.15.0"
+    "@rollup/rollup-darwin-x64" "4.15.0"
+    "@rollup/rollup-linux-arm-gnueabihf" "4.15.0"
+    "@rollup/rollup-linux-arm-musleabihf" "4.15.0"
+    "@rollup/rollup-linux-arm64-gnu" "4.15.0"
+    "@rollup/rollup-linux-arm64-musl" "4.15.0"
+    "@rollup/rollup-linux-powerpc64le-gnu" "4.15.0"
+    "@rollup/rollup-linux-riscv64-gnu" "4.15.0"
+    "@rollup/rollup-linux-s390x-gnu" "4.15.0"
+    "@rollup/rollup-linux-x64-gnu" "4.15.0"
+    "@rollup/rollup-linux-x64-musl" "4.15.0"
+    "@rollup/rollup-win32-arm64-msvc" "4.15.0"
+    "@rollup/rollup-win32-ia32-msvc" "4.15.0"
+    "@rollup/rollup-win32-x64-msvc" "4.15.0"
     fsevents "~2.3.2"
 
 run-parallel@^1.1.9:


### PR DESCRIPTION
## Background
메인 페이지 디자인 768px 추가 및 기타 수정
스터디 그룹 호출 함수 추가 (useInfinityQuery)
msw 데이터 추가

## Details
[디자인]
w-768px 디자인 추가 및 w 크기 통일(100%-mx-4)
헤더 컴포넌트 분리 (my-page, / 의 url인 경우 추가)
Fnb는 나중에 추가 예정

[생성된 스터디 그룹 호출]
useInfinityQuery를 통한 생성된 스터디 그룹 호출 - 리팩토링 x
msw를 통한 구현


## Discuss
헤더 컴포넌트가 3개인데 이를 url마다 각각 불러올지, 각 page 컴포넌트에 추가할 지 생각해봐야 할 것 같습니다.

## UI Images
![image](https://github.com/user-attachments/assets/b91960ec-6ca4-43c1-9a6b-adf0a79772c8)
![image](https://github.com/user-attachments/assets/4d0f96f0-5884-4b74-abbd-0180056925ca)
