### PR TITLE
[feat]: 스터디 목록 페이지 구현(참여 예정, 참여 중, 완료)

### DIFF
--- a/src/api/myPageApi.ts
+++ b/src/api/myPageApi.ts
@@ -27,5 +27,17 @@ const myPageApi = {
     );
     return response;
   },
+  getUpcomingList: async () => {
+    const { data: response } = await client.get(`/study-status/registered/`);
+    return response;
+  },
+  getOngoingList: async () => {
+    const { data: response } = await client.get(`/study-status/ongoing/`);
+    return response;
+  },
+  getCompletedList: async () => {
+    const { data: response } = await client.get(`/study-status/completed/`);
+    return response;
+  },
 };
 export default myPageApi;

--- a/src/components/HeaderWithBack.tsx
+++ b/src/components/HeaderWithBack.tsx
@@ -18,17 +18,17 @@ export default function HeaderWithBack({
 
   return (
     <header
-      className={`fixed z-[999] top-0 flex items-center w-full h-[52px] pl-2 pr-4 max-w-3xl ${isStudyPage ? 'bg-main text-white' : 'text-main border-b border-b-main'}`}
+      className={`fixed top-0 z-[999] flex h-[52px] w-full max-w-3xl items-center pr-4 pl-2 ${isStudyPage ? 'bg-main text-white' : 'text-main border-b-main border-b bg-white'}`}
     >
       <button onClick={() => navigate(-1)} aria-label="뒤로 가기">
-        <ChevronLeftIcon alt="뒤로 가기" className="cursor-pointer transition-colors hover:text-white-gray" />
+        <ChevronLeftIcon alt="뒤로 가기" className="hover:text-white-gray cursor-pointer transition-colors" />
       </button>
       <h1 className="absolute left-1/2 -translate-x-1/2 font-bold">{title}</h1>
       {action && (
         <button
           onClick={action.onClick}
           aria-label={action.ariaLabel}
-          className="ml-auto hover:text-white-gray transition-colors cursor-pointer"
+          className="hover:text-white-gray ml-auto cursor-pointer transition-colors"
         >
           {action?.icon && <action.icon alt="icon description" />}
         </button>

--- a/src/components/my-page/StudyItem.tsx
+++ b/src/components/my-page/StudyItem.tsx
@@ -1,0 +1,34 @@
+import { StudyItemType, StudyStatusType } from '../../types/interface';
+import PointIcon from '../../assets/icons/point.svg';
+
+export default function StudyItem({ study, studyType }: { study: StudyItemType; studyType: StudyStatusType }) {
+  const { gatherDate, title, enterPoint, tag, weeklyStudyTime } = study;
+  const isCompletedStudy = 'studyId' in study;
+
+  return (
+    <div
+      className={`border-light-gray flex w-full flex-col gap-y-1 rounded-sm border px-2.5 py-2 text-sm ${studyType === 'completed' ? 'h-[110px]' : 'h-[87px]'}`}
+    >
+      <div className="flex gap-x-1 text-xs font-medium">
+        <div className="border-light-gray flex items-center gap-x-[2px] rounded-full border px-1 py-[2px]">
+          <PointIcon alt="포인트" className="h-3.5 w-3.5" />
+          <span>{enterPoint.toLocaleString()}</span>
+        </div>
+        <span className="border-light-gray rounded-full border px-1 py-[2px]">{tag}</span>
+        <span className="border-light-gray rounded-full border px-1 py-[2px]">{weeklyStudyTime}시간</span>
+      </div>
+      <p className="font-medium">{title}</p>
+      <p className="text-dark-gray">스터디 기간: {gatherDate}</p>
+      {isCompletedStudy && (
+        <div className="flex gap-x-2.5">
+          <span>
+            획득한 포인트: <span className="text-topup font-bold">{study.obtainedPoint.toLocaleString()} P</span>
+          </span>
+          <span>
+            차감된 포인트: <span className="text-deduct font-bold">{study.deductedPoint.toLocaleString()} P</span>
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/my-page/useFetchStudyList.ts
+++ b/src/hooks/my-page/useFetchStudyList.ts
@@ -1,0 +1,34 @@
+import { useQuery } from '@tanstack/react-query';
+import { StudyStatusType, StudyItemType } from '../../types/interface';
+import myPageApi from '../../api/myPageApi';
+import { useMemo } from 'react';
+
+export default function useFetchStudyList(studyType: StudyStatusType) {
+  const apiFunctions: Record<StudyStatusType, () => Promise<StudyItemType[]>> = {
+    upcoming: myPageApi.getUpcomingList,
+    ongoing: myPageApi.getOngoingList,
+    completed: myPageApi.getCompletedList,
+  };
+
+  const { data, refetch, isLoading } = useQuery<StudyItemType[]>({
+    queryKey: [studyType],
+    queryFn: apiFunctions[studyType],
+  });
+
+  const studyList = useMemo(() => {
+    if (!data) return [];
+    const listMapping: Record<StudyStatusType, StudyItemType[]> = {
+      // api 구현될 시 수정 필요
+      upcoming: data,
+      ongoing: data,
+      completed: data,
+    };
+    return listMapping[studyType] || [];
+  }, [data, studyType]);
+
+  return {
+    studyList,
+    refetch,
+    isLoading,
+  };
+}

--- a/src/hooks/my-page/useStudyList.ts
+++ b/src/hooks/my-page/useStudyList.ts
@@ -1,0 +1,19 @@
+import { useLocation } from 'react-router-dom';
+import useFetchStudyList from './useFetchStudyList';
+import { StudyStatusType } from '../../types/interface';
+
+export default function useStudyList() {
+  const location = useLocation();
+  const queryParams = new URLSearchParams(location.search);
+  const studyType: StudyStatusType = (queryParams.get('status') as StudyStatusType) || 'upcoming';
+  const title =
+    studyType === 'upcoming'
+      ? '참여할 스터디 목록'
+      : studyType === 'ongoing'
+        ? '참여 중인 스터디 목록'
+        : studyType === 'completed'
+          ? '완료한 스터디 목록'
+          : '';
+  const { studyList, isLoading } = useFetchStudyList(studyType);
+  return { studyType, title, studyList, isLoading };
+}

--- a/src/mocks/data/dummy.ts
+++ b/src/mocks/data/dummy.ts
@@ -1,4 +1,11 @@
-import { UserProfile, AvgStats, StudyRoomType } from '../../types/interface';
+import {
+  UserProfile,
+  AvgStats,
+  StudyRoomType,
+  UpcomingStudyItem,
+  OnGoingStudyItem,
+  CompletedStudyItem,
+} from '../../types/interface';
 
 export const ProfileData: UserProfile = {
   userId: 1,
@@ -54,5 +61,75 @@ export const mockStudyRoomList: StudyRoomType[] = [
     current_members: 2,
     max_members: 6,
     status: '진행중',
+  },
+];
+export const upcomingStudies: UpcomingStudyItem[] = [
+  {
+    recruit_id: 1,
+    gatherDate: '2025-03-01 ~ 2025-08-01',
+    title: '8월 CPA 준비 스터디',
+    enterPoint: 3000,
+    tag: 'CPA',
+    weeklyStudyTime: 10,
+  },
+  {
+    recruit_id: 2,
+    gatherDate: '2025-05-15 ~ 2025-11-15',
+    title: '프론트엔드 개발 스터디',
+    enterPoint: 2000,
+    tag: '프론트엔드',
+    weeklyStudyTime: 8,
+  },
+];
+
+export const ongoingStudies: OnGoingStudyItem[] = [
+  {
+    registerId: 1,
+    gatherDate: '2024-11-01 ~ 2025-05-01',
+    title: 'SAT 준비 스터디',
+    enterPoint: 5000,
+    tag: 'SAT',
+    weeklyStudyTime: 12,
+  },
+  {
+    registerId: 2,
+    gatherDate: '2024-10-01 ~ 2025-04-01',
+    title: '영어 회화 스터디',
+    enterPoint: 3000,
+    tag: '영어',
+    weeklyStudyTime: 6,
+  },
+];
+
+export const completedStudies: CompletedStudyItem[] = [
+  {
+    studyId: 1,
+    deductedPoint: 100,
+    obtainedPoint: 200,
+    gatherDate: '2024-12-15 ~ 2025-01-15',
+    title: 'C++ 프로그래밍 스터디',
+    enterPoint: 5000,
+    tag: 'C++',
+    weeklyStudyTime: 8,
+  },
+  {
+    studyId: 2,
+    deductedPoint: 50,
+    obtainedPoint: 1500,
+    gatherDate: '2024-11-10 ~ 2024-12-10',
+    title: '웹 개발 프로젝트 스터디',
+    enterPoint: 3000,
+    tag: '웹 개발',
+    weeklyStudyTime: 10,
+  },
+  {
+    studyId: 3,
+    deductedPoint: 2000,
+    obtainedPoint: 350,
+    gatherDate: '2024-10-05 ~ 2024-11-05',
+    title: 'Java 알고리즘 스터디',
+    enterPoint: 4000,
+    tag: 'Java',
+    weeklyStudyTime: 12,
   },
 ];

--- a/src/mocks/myPageHandlers.ts
+++ b/src/mocks/myPageHandlers.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from 'msw';
-import { ProfileData, AvgStatsData } from './data/dummy';
+import { ProfileData, AvgStatsData, upcomingStudies, ongoingStudies, completedStudies } from './data/dummy';
 
 interface ModifyNicknameRequest {
   nickName: string;
@@ -30,6 +30,18 @@ const myPageHandlers = [
       message: '닉네임이 성공적으로 수정되었습니다.',
       nickname: nickName,
     });
+  }),
+  http.get('/study-status/registered/', () => {
+    if (upcomingStudies) return HttpResponse.json(upcomingStudies);
+    return HttpResponse.error();
+  }),
+  http.get('/study-status/ongoing/', () => {
+    if (ongoingStudies) return HttpResponse.json(ongoingStudies);
+    return HttpResponse.error();
+  }),
+  http.get('/study-status/completed/', () => {
+    if (completedStudies) return HttpResponse.json(completedStudies);
+    return HttpResponse.error();
   }),
 ];
 export default myPageHandlers;

--- a/src/pages/StudyList.tsx
+++ b/src/pages/StudyList.tsx
@@ -9,7 +9,7 @@ export default function StudyList() {
   return (
     <div>
       <HeaderWithBack title={title} />
-      <section className="flex flex-col gap-y-2 px-4 pt-3">
+      <section className="flex flex-col gap-y-2 px-4 pt-3 pb-7">
         {studyList.map((studyItem, index) => (
           <StudyItem study={studyItem} studyType={studyType} key={index} />
         ))}

--- a/src/pages/StudyList.tsx
+++ b/src/pages/StudyList.tsx
@@ -1,0 +1,19 @@
+import HeaderWithBack from '../components/HeaderWithBack';
+import useStudyList from '../hooks/my-page/useStudyList';
+import StudyItem from '../components/my-page/StudyItem';
+
+export default function StudyList() {
+  const { studyType, title, studyList, isLoading } = useStudyList();
+  if (!studyList || isLoading) return;
+
+  return (
+    <div>
+      <HeaderWithBack title={title} />
+      <section className="flex flex-col gap-y-2 px-4 pt-3">
+        {studyList.map((studyItem, index) => (
+          <StudyItem study={studyItem} studyType={studyType} key={index} />
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -12,6 +12,7 @@ const Study = lazy(() => import('../pages/Study'));
 const EditStudy = lazy(() => import('../pages/EditStudy'));
 const Group = lazy(() => import('../pages/Group'));
 const Search = lazy(() => import('../pages/Search'));
+const StudyList = lazy(() => import('../pages/StudyList'));
 
 const Router = (): JSX.Element => {
   return (
@@ -28,6 +29,7 @@ const Router = (): JSX.Element => {
           <Route path="/study" element={<Study />} />
           <Route path="/edit-study/:studyId" element={<EditStudy />} />
           <Route path="/search" element={<Search />} />
+          <Route path="/study-list" element={<StudyList />} />
         </Route>
       </Routes>
     </Suspense>

--- a/src/types/interface.ts
+++ b/src/types/interface.ts
@@ -32,3 +32,23 @@ export interface FilterType {
   studyTimeRange: [number, number];
   point: [number, number];
 }
+export interface UpcomingStudyItem extends StudyItem {
+  recruit_id: number;
+}
+export interface OnGoingStudyItem extends StudyItem {
+  registerId: number;
+}
+export interface CompletedStudyItem extends StudyItem {
+  studyId: number;
+  deductedPoint: number;
+  obtainedPoint: number;
+}
+export interface StudyItem {
+  gatherDate: string;
+  title: string;
+  enterPoint: number;
+  tag: string;
+  weeklyStudyTime: number;
+}
+export type StudyItemType = UpcomingStudyItem | OnGoingStudyItem | CompletedStudyItem;
+export type StudyStatusType = 'ongoing' | 'upcoming' | 'completed';


### PR DESCRIPTION
## Background
참여 예정인, 참여 중인, 완료한 스터디 목록 페이지 UI 구현 및 msw 바인딩

## Details
페이지 경로는 
- http://localhost:3000/study-list?status=completed
-  http://localhost:3000/study-list?status=ongoing
- http://localhost:3000/study-list?status=upcoming
쿼리 파라미터를 사용해 구현하였습니다.

[공통]
뒤로 가기 버튼 header에도 bg-white 적용
## UI Images
![image](https://github.com/user-attachments/assets/1ab0a2cb-f0e3-4d8d-9eb1-7cc126fcbd96)
