### PR TITLE
[feat] 마이 페이지와 스터디 목록 페이지 연결 및 마이 페이지 높이 설정

### DIFF
--- a/src/components/my-page/AverageStats.tsx
+++ b/src/components/my-page/AverageStats.tsx
@@ -26,7 +26,7 @@ export default function AverageStats({ averageStats, nickName }: { averageStats:
     <section className="text-sm">
       <p className="mb-2.5 font-medium">지난 일주일 동안 {nickName}님은 다른 사용자들보다</p>
       <div className="mx-auto flex w-[324px] gap-x-5">
-        <div className="bg-third relative flex h-[152px] w-[152px] flex-col items-center justify-center rounded-lg">
+        <div className="border-white-gray relative flex h-[152px] w-[152px] flex-col items-center justify-center rounded-lg border">
           <BarChart data={todoData} width={52} height={100}>
             <Bar dataKey="value1" className="fill-white-gray" radius={[2, 2, 0, 0]} />
             <Bar dataKey="value2" className="fill-main" radius={[2, 2, 0, 0]} />
@@ -37,7 +37,7 @@ export default function AverageStats({ averageStats, nickName }: { averageStats:
             <br /> 투두를 완료했어요
           </p>
         </div>
-        <div className="bg-third relative flex h-[152px] w-[152px] flex-col items-center justify-center rounded-lg">
+        <div className="border-white-gray relative flex h-[152px] w-[152px] flex-col items-center justify-center rounded-lg border">
           <BarChart data={studyTimeData} width={52} height={100}>
             <Bar dataKey="value1" className="fill-white-gray" radius={[2, 2, 0, 0]} />
             <Bar dataKey="value2" className="fill-main" radius={[2, 2, 0, 0]} />

--- a/src/components/my-page/ProfileSection.tsx
+++ b/src/components/my-page/ProfileSection.tsx
@@ -45,7 +45,7 @@ export default function ProfileSection({ userData }: { userData: UserProfile }) 
       </section>
       <section className="my-4 text-sm">
         <p className="mb-2.5 font-medium">스터디 현황</p>
-        <div className="bg-third flex w-full justify-around rounded-md py-2">
+        <div className="border-white-gray flex w-full justify-around rounded-md border py-2">
           <Link className="flex cursor-pointer flex-col items-center font-medium" to="/study-list?status=upcoming">
             <span className="text-main">시작 전</span>
             <span>{applied}</span>

--- a/src/components/my-page/ProfileSection.tsx
+++ b/src/components/my-page/ProfileSection.tsx
@@ -3,6 +3,7 @@ import PointIcon from '../../assets/icons/point.svg';
 import { UserProfile } from '../../types/interface';
 import { overlay } from 'overlay-kit';
 import ProfileModifyModal from './ProfileModifyModal';
+import { Link } from 'react-router-dom';
 
 export default function ProfileSection({ userData }: { userData: UserProfile }) {
   const { nickName, points, applied, in_progress, completed, profileImage } = userData;
@@ -45,18 +46,18 @@ export default function ProfileSection({ userData }: { userData: UserProfile }) 
       <section className="my-4 text-sm">
         <p className="mb-2.5 font-medium">스터디 현황</p>
         <div className="bg-third flex w-full justify-around rounded-md py-2">
-          <button className="flex cursor-pointer flex-col items-center font-medium">
+          <Link className="flex cursor-pointer flex-col items-center font-medium" to="/study-list?status=upcoming">
             <span className="text-main">시작 전</span>
             <span>{applied}</span>
-          </button>
-          <button className="flex cursor-pointer flex-col items-center font-medium">
+          </Link>
+          <Link className="flex cursor-pointer flex-col items-center font-medium" to="/study-list?status=ongoing">
             <span className="text-main">진행 중</span>
             <span>{in_progress}</span>
-          </button>
-          <button className="flex cursor-pointer flex-col items-center font-medium">
+          </Link>
+          <Link className="flex cursor-pointer flex-col items-center font-medium" to="/study-list?status=completed">
             <span className="text-main">완료</span>
             <span>{completed}</span>
-          </button>
+          </Link>
         </div>
       </section>
     </div>

--- a/src/components/my-page/ProfileSection.tsx
+++ b/src/components/my-page/ProfileSection.tsx
@@ -20,7 +20,7 @@ export default function ProfileSection({ userData }: { userData: UserProfile }) 
   };
 
   return (
-    <div className="h-full w-full">
+    <div>
       <section className="flex gap-x-4">
         <img src={profileImage} alt={nickName} className="h-12 w-12 rounded-full" />
         <div className="flex flex-col gap-y-0.5">

--- a/src/layouts/Layout.tsx
+++ b/src/layouts/Layout.tsx
@@ -9,12 +9,12 @@ export default function Layout() {
   return (
     <>
       {(url === '/' || url === '/my-page') && <Header />}
-      <main className="after:bg-white-gray before:bg-white-gray relative mx-auto flex min-h-screen w-full max-w-3xl flex-col justify-between pt-[52px] before:absolute before:right-0 before:bottom-0 before:h-[calc(100%-52px)] before:w-[1px] before:content-[''] after:absolute after:bottom-0 after:left-0 after:h-[calc(100%-52px)] after:w-[1px] after:content-['']">
+      <main className="after:bg-white-gray before:bg-white-gray relative mx-auto flex h-screen w-full max-w-3xl flex-col justify-between pt-[52px] before:absolute before:right-0 before:bottom-0 before:h-[calc(100%-52px)] before:w-[1px] before:content-[''] after:absolute after:bottom-0 after:left-0 after:h-[calc(100%-52px)] after:w-[1px] after:content-['']">
         <Outlet key={url} />
       </main>
-      {url === '/' && <Fnb nav={"홈"} />}
-      {url === '/group' && <Fnb nav={"그룹"} />}
-      {url === '/my-page' && <Fnb nav={"마이"} />}
+      {url === '/' && <Fnb nav={'홈'} />}
+      {url === '/group' && <Fnb nav={'그룹'} />}
+      {url === '/my-page' && <Fnb nav={'마이'} />}
     </>
   );
 }

--- a/src/mocks/data/dummy.ts
+++ b/src/mocks/data/dummy.ts
@@ -66,7 +66,7 @@ export const mockStudyRoomList: StudyRoomType[] = [
 export const upcomingStudies: UpcomingStudyItem[] = [
   {
     recruit_id: 1,
-    gatherDate: '2025-03-01 ~ 2025-08-01',
+    gatherDate: '2025.03.01 ~ 2025.08.01',
     title: '8월 CPA 준비 스터디',
     enterPoint: 3000,
     tag: 'CPA',
@@ -74,7 +74,7 @@ export const upcomingStudies: UpcomingStudyItem[] = [
   },
   {
     recruit_id: 2,
-    gatherDate: '2025-05-15 ~ 2025-11-15',
+    gatherDate: '2025.05.15 ~ 2025.11.15',
     title: '프론트엔드 개발 스터디',
     enterPoint: 2000,
     tag: '프론트엔드',
@@ -85,7 +85,7 @@ export const upcomingStudies: UpcomingStudyItem[] = [
 export const ongoingStudies: OnGoingStudyItem[] = [
   {
     registerId: 1,
-    gatherDate: '2024-11-01 ~ 2025-05-01',
+    gatherDate: '2024.11.01 ~ 2025.05.01',
     title: 'SAT 준비 스터디',
     enterPoint: 5000,
     tag: 'SAT',
@@ -93,7 +93,7 @@ export const ongoingStudies: OnGoingStudyItem[] = [
   },
   {
     registerId: 2,
-    gatherDate: '2024-10-01 ~ 2025-04-01',
+    gatherDate: '2024.10.01 ~ 2025.04.01',
     title: '영어 회화 스터디',
     enterPoint: 3000,
     tag: '영어',
@@ -106,7 +106,7 @@ export const completedStudies: CompletedStudyItem[] = [
     studyId: 1,
     deductedPoint: 100,
     obtainedPoint: 200,
-    gatherDate: '2024-12-15 ~ 2025-01-15',
+    gatherDate: '2024.12.15 ~ 2025.01.15',
     title: 'C++ 프로그래밍 스터디',
     enterPoint: 5000,
     tag: 'C++',
@@ -116,7 +116,7 @@ export const completedStudies: CompletedStudyItem[] = [
     studyId: 2,
     deductedPoint: 50,
     obtainedPoint: 1500,
-    gatherDate: '2024-11-10 ~ 2024-12-10',
+    gatherDate: '2024.11.10 ~ 2024.12.10',
     title: '웹 개발 프로젝트 스터디',
     enterPoint: 3000,
     tag: '웹 개발',
@@ -126,7 +126,7 @@ export const completedStudies: CompletedStudyItem[] = [
     studyId: 3,
     deductedPoint: 2000,
     obtainedPoint: 350,
-    gatherDate: '2024-10-05 ~ 2024-11-05',
+    gatherDate: '2024.10.05 ~ 2024.11.05',
     title: 'Java 알고리즘 스터디',
     enterPoint: 4000,
     tag: 'Java',

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -11,10 +11,12 @@ function MyPage() {
   if (!userData || isUserDataLoading || !averageStats || isAvgLoading) return;
 
   return (
-    <div className="px-4 pt-7">
-      <ProfileSection userData={userData} />
-      <AverageStats averageStats={averageStats} nickName={userData.nickName} />
-      <Button text="포인트 출금하고 내역을 볼 수 있어요" onClick={() => navigate('/points')} extraClass="mt-[80px]" />
+    <div className="flex h-[calc(100%-60px)] flex-col justify-between px-4 py-7">
+      <div>
+        <ProfileSection userData={userData} />
+        <AverageStats averageStats={averageStats} nickName={userData.nickName} />
+      </div>
+      <Button text="포인트 출금하고 내역을 볼 수 있어요" onClick={() => navigate('/points')} />
     </div>
   );
 }


### PR DESCRIPTION
## Background
마이 페이지내 스터디 목록 페이지로 이동할 수 있도록 연결하였고 레이아웃의 높이 min-h-screen에서 h-screen으로 변경
## Details
- 스터디 목록 dummy 데이터 날짜 형식 변경
- 마이 페이지 높이 설정 및 레이아웃 높이(min-h-screen -> h-screen) 변경
- 마이페이지 내 스터디 목록 페이지 Link태그로 이동할 수 있도록 연결
- 마이페이지 디자인 변경
## UI Images
![image](https://github.com/user-attachments/assets/63a306a0-c338-4e8d-981f-4ddc3f42fa9c)
