### PR TITLE
[fix] MSW를 이용한 프로필 수정 로직 업데이트

### DIFF
--- a/src/components/my-page/ProfileModifyModal.tsx
+++ b/src/components/my-page/ProfileModifyModal.tsx
@@ -10,16 +10,19 @@ export default function ProfileModifyModal({
   nickName,
   isOpen,
   close,
+  userId,
 }: {
   userImg: string;
   nickName: string;
   isOpen: boolean;
   close: () => void;
+  userId: number;
 }) {
   const { profile, handleImgUpload, handleClick, fileInputRef, onNickNameChange, handleModifyProfile, error } =
     useModifyProfile({
       userImg,
       nickName,
+      userId,
     });
   if (!isOpen) return;
   return (

--- a/src/components/my-page/ProfileSection.tsx
+++ b/src/components/my-page/ProfileSection.tsx
@@ -5,7 +5,7 @@ import { overlay } from 'overlay-kit';
 import ProfileModifyModal from './ProfileModifyModal';
 import { Link } from 'react-router-dom';
 
-export default function ProfileSection({ userData }: { userData: UserProfile }) {
+export default function ProfileSection({ userData, userId }: { userData: UserProfile; userId: number }) {
   const { nickName, points, applied, in_progress, completed, profileImage } = userData;
   const openOverlay = () => {
     overlay.open(({ isOpen, close }) => {
@@ -15,6 +15,7 @@ export default function ProfileSection({ userData }: { userData: UserProfile }) 
           nickName={userData.nickName}
           isOpen={isOpen}
           close={close}
+          userId={userId}
         />
       );
     });

--- a/src/hooks/my-page/useModifyNickName.ts
+++ b/src/hooks/my-page/useModifyNickName.ts
@@ -1,16 +1,15 @@
 import { useMutation } from '@tanstack/react-query';
 import myPageApi from '../../api/myPageApi';
+import useProfile from './useProfile';
+import { ModifyNickNameProps } from '../../types/interface';
 
-export default function useModifyNickName(
-  prevNickName: string,
-  currentNickName: string,
-  setError: (error: string) => void,
-) {
+export default function useModifyNickName({ currentNickName, setError, userId }: ModifyNickNameProps) {
+  const { reloadProfile } = useProfile(userId);
   const mutation = useMutation({
     mutationFn: async () => {
-      if (!prevNickName || prevNickName === currentNickName) return;
       await myPageApi.modifyNickName(currentNickName);
     },
+    onSuccess: () => reloadProfile(),
     onError: () => setError('중복된 닉네임이에요'),
   });
   return { modifyNickName: mutation.mutate };

--- a/src/hooks/my-page/useModifyProfile.ts
+++ b/src/hooks/my-page/useModifyProfile.ts
@@ -3,16 +3,31 @@ import { ChangeEvent } from 'react';
 import useModifyNickName from './useModifyNickName';
 import useModifyProfileImg from './useModifyProfileImg';
 
-export default function useModifyProfile({ userImg, nickName }: { userImg: string; nickName: string }) {
+export default function useModifyProfile({
+  userImg,
+  nickName,
+  userId,
+}: {
+  userImg: string;
+  nickName: string;
+  userId: number;
+}) {
   const [profile, setProfile] = useState({ userImg: userImg, nickName: nickName });
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [error, setError] = useState('');
-  const { modifyNickName } = useModifyNickName(nickName, profile.nickName, setError);
-  const { modifyProfileImg } = useModifyProfileImg(userImg, profile.userImg);
+  const { modifyNickName } = useModifyNickName({
+    currentNickName: profile.nickName,
+    setError: setError,
+    userId,
+  });
+  const { modifyProfileImg } = useModifyProfileImg({ currentImg: profile.userImg, userId });
 
   const handleModifyProfile = async (close: () => void) => {
     try {
-      await Promise.all([modifyNickName(), modifyProfileImg()]);
+      const promises = [];
+      if (nickName !== profile.nickName && profile.nickName) promises.push(modifyNickName());
+      if (userImg !== profile.userImg && profile.userImg) promises.push(modifyProfileImg());
+      await Promise.all(promises);
       close();
     } catch (error) {
       console.error('Error modifying profile:', error);

--- a/src/hooks/my-page/useModifyProfileImg.ts
+++ b/src/hooks/my-page/useModifyProfileImg.ts
@@ -1,12 +1,14 @@
 import { useMutation } from '@tanstack/react-query';
 import myPageApi from '../../api/myPageApi';
+import useProfile from './useProfile';
 
-export default function useModifyProfileImg(prevImg: string, currentImg: string) {
+export default function useModifyProfileImg({ currentImg, userId }: { currentImg: string; userId: number }) {
+  const { reloadProfile } = useProfile(userId);
   const mutation = useMutation({
     mutationFn: async () => {
-      if (!prevImg || prevImg === currentImg) return;
       await myPageApi.modifyProfileImg(currentImg);
     },
+    onSuccess: () => reloadProfile(),
   });
   return { modifyProfileImg: mutation.mutate };
 }

--- a/src/hooks/my-page/useMyPage.ts
+++ b/src/hooks/my-page/useMyPage.ts
@@ -6,5 +6,5 @@ export default function useMyPage() {
   const { userData, isUserDataLoading } = useProfile(userId);
   const { averageStats, isAvgLoading } = useAverageStats(userId);
 
-  return { userData, isUserDataLoading, averageStats, isAvgLoading };
+  return { userData, isUserDataLoading, averageStats, isAvgLoading, userId };
 }

--- a/src/hooks/point/useWithdrawModal.ts
+++ b/src/hooks/point/useWithdrawModal.ts
@@ -1,16 +1,11 @@
 import { useState } from 'react';
-import useGetUserPoints from './useGetUserPoints';
 import useWithdrawPoint from './useWithdrawPoint';
-import useGetPointHistory from './useGetPointHistory';
 
 export default function useWithdrawModal(close: () => void, currentPoint: number) {
   const [inputPoint, setInputPoint] = useState(0);
   const [shaking, setShaking] = useState(false);
-  const { refetchUserPoints } = useGetUserPoints();
-  const { refetch: refetchAll } = useGetPointHistory('전체');
-  const { refetch: refetchWithdraw } = useGetPointHistory('출금');
 
-  const { withdrawPoint } = useWithdrawPoint(inputPoint, refetchUserPoints, refetchAll, refetchWithdraw);
+  const { withdrawPoint } = useWithdrawPoint(inputPoint);
   const isInputInValid = inputPoint < 1000 || (inputPoint !== 0 && inputPoint % 1000 !== 0);
   const [notification, setNotification] = useState('*출금은 1,000P 단위로 가능해요');
 

--- a/src/hooks/point/useWithdrawPoint.ts
+++ b/src/hooks/point/useWithdrawPoint.ts
@@ -1,12 +1,12 @@
 import { useMutation } from '@tanstack/react-query';
 import pointApi from '../../api/pointApi';
+import useGetUserPoints from './useGetUserPoints';
+import useGetPointHistory from './useGetPointHistory';
 
-export default function useWithdrawPoint(
-  amount: number,
-  refetchUserPoints: () => void,
-  refetchAll: () => void,
-  refetchWithdraw: () => void,
-) {
+export default function useWithdrawPoint(amount: number) {
+  const { refetchUserPoints } = useGetUserPoints();
+  const { refetch: refetchAll } = useGetPointHistory('전체');
+  const { refetch: refetchWithdraw } = useGetPointHistory('출금');
   const mutation = useMutation({
     mutationFn: async () => {
       await pointApi.withdrawPoint(amount);

--- a/src/mocks/myPageHandlers.ts
+++ b/src/mocks/myPageHandlers.ts
@@ -16,7 +16,9 @@ const myPageHandlers = [
   }),
   http.put('/user/profile-image/', async ({ request }) => {
     const formData = await request.formData();
-    const img = formData.get('image');
+    const img = formData.get('image') as string;
+    ProfileData.profileImage = img;
+
     return HttpResponse.json({
       success: true,
       message: '프로필 사진이 성공적으로 수정되었습니다.',
@@ -25,6 +27,7 @@ const myPageHandlers = [
   }),
   http.put('/user/nickname/', async ({ request }) => {
     const { nickName } = (await request.json()) as ModifyNicknameRequest;
+    ProfileData.nickName = nickName;
     return HttpResponse.json({
       success: true,
       message: '닉네임이 성공적으로 수정되었습니다.',

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -6,14 +6,14 @@ import Button from '../components/Button';
 import { useNavigate } from 'react-router-dom';
 
 function MyPage() {
-  const { userData, isUserDataLoading, averageStats, isAvgLoading } = useMyPage();
+  const { userData, isUserDataLoading, averageStats, isAvgLoading, userId } = useMyPage();
   const navigate = useNavigate();
   if (!userData || isUserDataLoading || !averageStats || isAvgLoading) return;
 
   return (
     <div className="flex h-[calc(100%-60px)] flex-col justify-between px-4 py-7">
       <div>
-        <ProfileSection userData={userData} />
+        <ProfileSection userData={userData} userId={userId} />
         <AverageStats averageStats={averageStats} nickName={userData.nickName} />
       </div>
       <Button text="포인트 출금하고 내역을 볼 수 있어요" onClick={() => navigate('/point')} />

--- a/src/types/interface.ts
+++ b/src/types/interface.ts
@@ -76,3 +76,8 @@ export type PointFilterType = '전체' | '충전' | '차감' | '출금';
 export interface WithdrawRequest extends Record<string, unknown> {
   amount: number;
 }
+export interface ModifyNickNameProps {
+  currentNickName: string;
+  setError: (error: string) => void;
+  userId: number;
+}


### PR DESCRIPTION
## Background
프로필 수정 로직에 닉네임 및 프로필 사진 변경 시, 변경 사항을 즉시 업데이트 할 수 있도록 로직을 추가했습니다.

## Details
- 프로필 사진, 닉네임이 변경될 때, 이미지, 닉네임를 즉시 반영하여 사용자가 변경된 이미지를 바로 확인할 수 있도록 구현했습니다.
- MSW를 활용하여 API 호출을 모킹하고 로컬 환경에서 테스트할 수 있게 했습니다.

*포인트 API의 리페치 호출 위치를 변경하여, props로 전달하는 방식 대신 직접 호출 위치에서 커스텀 훅을 사용하도록 수정했습니다.