### PR TITLE
[feat] 진행 중인 스터디 목록 및 세부 페이지 Link 연동

### DIFF
--- a/src/components/Fnb.tsx
+++ b/src/components/Fnb.tsx
@@ -5,8 +5,8 @@ import { useNavigate } from 'react-router-dom';
 
 export default function Fnb({ nav }: { nav: string }) {
   const navList = [
-    { icon: Home, text: '홈', ariaLabel: '메인 페이지로 이동', path: '/' },
-    { icon: Group, text: '그룹', ariaLabel: '그룹 페이지로 이동', path: '/group' },
+    { icon: Home, text: '모집', ariaLabel: '메인 페이지로 이동', path: '/' },
+    { icon: Group, text: '진행', ariaLabel: '진행 페이지로 이동', path: '/study' },
     { icon: User, text: '마이', ariaLabel: '마이 페이지로 이동', path: '/my-page' },
   ];
   const navigate = useNavigate();

--- a/src/components/home/StudyRecruitList.tsx
+++ b/src/components/home/StudyRecruitList.tsx
@@ -1,0 +1,79 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import client from '../../utils/client';
+import { useEffect, useRef } from 'react';
+import { Link } from 'react-router-dom';
+
+const fetchStudies = async (pageParam = 1) => {
+  const { data } = await client.get(`/api/recruits?page=${pageParam}`);
+  return data.result.recruits;
+};
+
+export default function StudyRecruitList(): JSX.Element {
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery({
+    queryKey: ['study-recruit-list'],
+    queryFn: ({ pageParam = 1 }) => fetchStudies(pageParam),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage, allPages) => {
+      return lastPage.hasMore ? allPages.length + 1 : undefined;
+    },
+  });
+  const observerRef = useRef(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) {
+          fetchNextPage();
+        }
+      },
+      { threshold: 1.0 },
+    );
+    if (observerRef.current) {
+      observer.observe(observerRef.current);
+    }
+    return () => {
+      if (observerRef.current) {
+        observer.unobserve(observerRef.current);
+      }
+    };
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+
+  return (
+    <div
+      className="scrollbar-hide mt-3 flex w-full flex-col items-center gap-[5px] overflow-y-scroll"
+      style={{ height: `calc(100vh - 250px)` }}
+    >
+      {data?.pages
+        .flatMap((page) => page)
+        .map((study) => (
+          <Link
+            key={study.recruitId}
+            to={`/study-recruit/${study.recruitId}`}
+            className="border-white-gray w-full rounded-[10px] border bg-white p-3"
+          >
+            <div className="mb-2">
+              <p className="font-bold">{study.title + ' (' + study.category + ')'}</p>
+              <p className="text-gray text-sm">
+                스터디원 ( {study.currentMembers} / {study.maxMembers} ) 명
+              </p>
+            </div>
+            <div className="text-gray text-sm">
+              <p>
+                스터디 기간: {study.studyStartAt.split('T')[0]} ~ {study.studyEndAt.split('T')[0]}
+              </p>
+              <p>모집 기간 ~{study.recruitEndAt.split('T')[0]}</p>
+              <p>모집중</p>
+            </div>
+            <div className="mt-2 flex gap-2">
+              {study.tags.map((tag: string) => (
+                <p key={tag} className="bg-white-gray rounded-md px-2 py-1 text-xs">
+                  #{tag}
+                </p>
+              ))}
+            </div>
+          </Link>
+        ))}
+      <div ref={observerRef} className="h-10" />
+    </div>
+  );
+}

--- a/src/components/studyRoom/StudyRoomList.tsx
+++ b/src/components/studyRoom/StudyRoomList.tsx
@@ -4,13 +4,13 @@ import { useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom';
 
 const fetchStudies = async (pageParam = 1) => {
-  const { data } = await client.get(`/api/recruits?page=${pageParam}`);
-  return data.result.recruits;
+  const { data } = await client.get(`/api/rooms?page=${pageParam}`);
+  return data.result.rooms;
 };
 
-export default function StudyRoom(): JSX.Element {
+export default function StudyRoomList(): JSX.Element {
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery({
-    queryKey: ['study-recruit-list'],
+    queryKey: ['study-room-list'],
     queryFn: ({ pageParam = 1 }) => fetchStudies(pageParam),
     initialPageParam: 1,
     getNextPageParam: (lastPage, allPages) => {
@@ -48,7 +48,7 @@ export default function StudyRoom(): JSX.Element {
         .map((study) => (
           <Link
             key={study.recruitId}
-            to={`/study-recruit/${study.recruitId}`}
+            to={`/study/${study.recruitId}`}
             className="border-white-gray w-full rounded-[10px] border bg-white p-3"
           >
             <div className="mb-2">
@@ -61,8 +61,7 @@ export default function StudyRoom(): JSX.Element {
               <p>
                 스터디 기간: {study.studyStartAt.split('T')[0]} ~ {study.studyEndAt.split('T')[0]}
               </p>
-              <p>모집 기간 ~{study.recruitEndAt.split('T')[0]}</p>
-              <p>{study.status}</p>
+              <p>진행중</p>
             </div>
             <div className="mt-2 flex gap-2">
               {study.tags.map((tag: string) => (

--- a/src/layouts/Layout.tsx
+++ b/src/layouts/Layout.tsx
@@ -8,12 +8,14 @@ export default function Layout() {
 
   return (
     <>
-      {(url === '/' || url === '/my-page') && <Header />}
+      {url === '/' && <Header />}
+      {url === '/my-page' && <Header />}
+      {url === '/study' && <Header />}
       <main className="md:before:bg-white-gray md:after:bg-white-gray relative mx-auto flex h-screen w-full max-w-3xl flex-col justify-between pt-[52px] md:before:absolute md:before:right-0 md:before:bottom-0 md:before:h-[calc(100%-52px)] md:before:w-[1px] md:before:content-[''] md:after:absolute md:after:bottom-0 md:after:left-0 md:after:h-[calc(100%-52px)] md:after:w-[1px] md:after:content-['']">
         <Outlet key={url} />
       </main>
-      {url === '/' && <Fnb nav={'홈'} />}
-      {url === '/group' && <Fnb nav={'그룹'} />}
+      {url === '/' && <Fnb nav={'모집'} />}
+      {url === '/study' && <Fnb nav={'진행'} />}
       {url === '/my-page' && <Fnb nav={'마이'} />}
     </>
   );

--- a/src/mocks/studyRoomHandlers.ts
+++ b/src/mocks/studyRoomHandlers.ts
@@ -24,6 +24,27 @@ export const studyRoomHandlers = [
     });
   }),
 
+  // 진행 중인 스터디룸 목록 조회
+  http.get(`/api/rooms`, ({ request }) => {
+    console.log('스터디 목록 조회');
+    const url = new URL(request.url);
+    const page = parseInt(url.searchParams.get('page') || '1', 10);
+    const limit = 5;
+    const start = (page - 1) * limit;
+    const end = start + limit;
+    const hasNextPage = end < mockStudyRoomList.length;
+
+    return HttpResponse.json({
+      status: 'OK',
+      code: 200,
+      message: '스터디를 조회했습니다.',
+      result: {
+        rooms: mockStudyRoomList.slice(start, end),
+        nextPage: hasNextPage ? page + 1 : null,
+      },
+    });
+  }),
+
   // 스터디 모집 글 생성
   http.post(`/api/recruits`, async ({ request }) => {
     const body = (await request.json()) as StudyRoomPostType;
@@ -50,6 +71,21 @@ export const studyRoomHandlers = [
       status: 'OK',
       code: 200,
       message: '스터디 모집 글 상세 조회 생성되었습니다.',
+      result: {
+        ...studyRoom,
+      },
+    });
+  }),
+
+  // 스터디 상세 조회
+  http.get(`/api/rooms/:roomId`, ({ params }) => {
+    const recruitId = params.recruitId;
+    const studyRoom = mockStudyRoomList.find((room) => room.recruitId === Number(recruitId));
+    console.log('스터디 모집 글 상세 조회', studyRoom);
+    return HttpResponse.json({
+      status: 'OK',
+      code: 200,
+      message: '스터디 상세 조회 생성되었습니다.',
       result: {
         ...studyRoom,
       },

--- a/src/pages/Group.tsx
+++ b/src/pages/Group.tsx
@@ -1,7 +1,0 @@
-import React from 'react';
-
-const Group = React.memo((): JSX.Element => {
-  return <div>Group Page</div>;
-});
-
-export default Group;

--- a/src/pages/StudyRoom.tsx
+++ b/src/pages/StudyRoom.tsx
@@ -1,9 +1,9 @@
 import { Link } from 'react-router-dom';
 import { useSearchStore } from '../store/searchStore';
 import FilterList from '../components/home/FilterList';
-import StudyRecruitList from '../components/home/StudyRecruitList';
+import StudyRoomList from '../components/studyRoom/StudyRoomList';
 
-export default function Home(): JSX.Element {
+export default function StudyRoom(): JSX.Element {
   const { filteringInfo } = useSearchStore();
   const isLogin = true;
 
@@ -20,7 +20,7 @@ export default function Home(): JSX.Element {
           />
         </Link>
         <FilterList />
-        <StudyRecruitList />
+        <StudyRoomList />
       </div>
       <Link
         to={isLogin ? '/create-study' : '/login'}

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -11,7 +11,7 @@ const MyPage = lazy(() => import('../pages/MyPage'));
 const Point = lazy(() => import('../pages/Point'));
 const Study = lazy(() => import('../pages/Study'));
 const EditStudy = lazy(() => import('../pages/EditStudy'));
-const Group = lazy(() => import('../pages/Group'));
+const StudyRoom = lazy(() => import('../pages/StudyRoom'));
 const Search = lazy(() => import('../pages/Search'));
 const StudyList = lazy(() => import('../pages/StudyList'));
 
@@ -21,12 +21,14 @@ const Router = (): JSX.Element => {
       <Routes>
         <Route element={<Layout />}>
           <Route path="/" element={<Home />} />
-          <Route path="/group" element={<Group />} />
-          <Route path="/my-page" element={<MyPage />} />
           <Route path="/login" element={<Login />} />
+          <Route path="/my-page" element={<MyPage />} />
           <Route path="/create-study" element={<CreateStudy />} />
           <Route path="/study-recruit/:recruitId" element={<StudyRecruit />} />
           <Route path="/edit-recruit/:recruitId" element={<EditStudyRecruit />} />
+          <Route path="/study" element={<StudyRoom />} />
+          {/* <Route path="/study/:studyId:" element={<StudyRoom />} /> */}
+
           <Route path="/point" element={<Point />} />
           <Route path="/study" element={<Study />} />
           <Route path="/edit-study/:studyId" element={<EditStudy />} />


### PR DESCRIPTION
## Background
진행 중인 스터디 목록 UI 및 세부 페이지 연동

## Details
[진행 중인 스터디 목록 UI]
- 기존 모집 중 스터디 목록 UI와 같지만 상태 및 보여주는 목록을 다르게 처리
- fnb 변경 (홈, 그룹, 마이 -> 모집, 진행, 마이) # 이 부분 생각보다 UX가 별로일 것 같은데 다시 고민해 봐야 할 것 같습니다.
- 목록 클릭 시 글 세부 페이지로 이동 # 페이지를 만들진 않고 route에 주석 처리했습니다. 추후 페이지 생성 시 연동 예정입니다.

[msw 바인딩]
- studyRoomHandler에 진행 중인 스터디 관련 handler 추가

## Discuss


## UI Images
![image](https://github.com/user-attachments/assets/b622cfd4-f877-463a-90aa-53990a6da45a)
