### PR TITLE
Fix/kakao login

### DIFF
--- a/src/api/oauthApi.ts
+++ b/src/api/oauthApi.ts
@@ -19,7 +19,8 @@ const oauthApi = {
     return response;
   },
   logout: async () => {
-    await client.get('/api/auth/kakao-logout');
+    const { data: response } = await client.get('/api/auth/kakao-logout');
+    return response;
   },
   updateJWTToken: async (token: string, userId: string) => {
     const { data: response } = await client.post(`/api/auth/${userId}/refresh`, {

--- a/src/api/oauthApi.ts
+++ b/src/api/oauthApi.ts
@@ -2,7 +2,16 @@ import client from '../utils/client';
 
 const oauthApi = {
   postOauthCode: async (code: string | null) => {
-    const { data: response } = await client.post(`/api/kakao-login?code=${code}`);
+    const { data: response } = await client.post(
+      `/api/kakao-login?code=${code}`,
+      {},
+      {
+        headers: {
+          'Content-Type': 'application/json;charset=utf-8',
+          'Access-Control-Allow-Origin': '*',
+        },
+      },
+    );
     return response;
   },
   getUserLoginInfo: async () => {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,14 +1,31 @@
 import { Link } from 'react-router-dom';
 import Logo from '../assets/logo.webp';
-import Bell from '@/assets/icons/bell.svg';
+import { useAuthStore } from '../store/useAuthStore';
+import oauthApi from '../api/oauthApi';
 
 export default function Header() {
+  const { id, clearAuth } = useAuthStore();
+  const logout = async () => {
+    const response = await oauthApi.logout();
+    if (response.status === 200) {
+      clearAuth();
+    }
+  };
+
   return (
     <header className="md:border-white-gray fixed top-0 left-1/2 z-[999] mx-auto flex h-13 w-full max-w-3xl -translate-x-1/2 items-center justify-between bg-white px-4 md:border-x">
       <Link to={'/'} aria-label="홈으로">
         <img src={Logo} alt="Logo" className="h-auto w-20" />
       </Link>
-      <Bell alt="알림" />
+      {id === -1 ? (
+        <Link to={'/login'} className="text-main-text text-center text-sm font-bold">
+          로그인
+        </Link>
+      ) : (
+        <div className="text-center text-sm text-black" onClick={logout}>
+          로그아웃
+        </div>
+      )}
     </header>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -22,9 +22,9 @@ export default function Header() {
           로그인
         </Link>
       ) : (
-        <div className="text-main-text text-center text-sm font-bold" onClick={logout}>
+        <button className="text-main-text cursor-pointer text-center text-sm font-bold" onClick={logout}>
           로그아웃
-        </div>
+        </button>
       )}
     </header>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -22,7 +22,7 @@ export default function Header() {
           로그인
         </Link>
       ) : (
-        <div className="text-center text-sm text-black" onClick={logout}>
+        <div className="text-main-text text-center text-sm font-bold" onClick={logout}>
           로그아웃
         </div>
       )}

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -1,3 +1,8 @@
 export const CATEGORY = ['공무원', '대학 입시', '시험', '어학', '입용', '취업', '코딩', '기타'] as const;
 export const POINTFILTERS = ['전체', '충전', '차감', '출금', '보상', '환불'] as const;
 export const COLORS = ['#0074D9', '#FF6347', '#FFCC00', '#3D9970', '#B10DC9', '#001F3F', '#AAAAAA', '#F012BE'] as const;
+export const FNB_LIST: { [key: string]: string } = {
+  'recruit-list': '모집',
+  'study-list': '진행',
+  'my-page': '마이',
+};

--- a/src/constants/oauth.ts
+++ b/src/constants/oauth.ts
@@ -1,4 +1,4 @@
-const CLIENT_ID: string = import.meta.env.KAKAO_API;
-const REDIRECT_URI: string = import.meta.env.REDIRECT_URL;
+const CLIENT_ID: string = import.meta.env.VITE_KAKAO_API;
+const REDIRECT_URI: string = import.meta.env.VITE_REDIRECT_URL;
 
 export const KAKAO_AUTH_URL: string = `https://kauth.kakao.com/oauth/authorize?client_id=${CLIENT_ID}&redirect_uri=${REDIRECT_URI}&response_type=code`;

--- a/src/layouts/Layout.tsx
+++ b/src/layouts/Layout.tsx
@@ -1,22 +1,20 @@
 import { Outlet, useLocation } from 'react-router-dom';
 import Header from '../components/Header';
 import Fnb from '../components/Fnb';
+import { FNB_LIST } from '../constants/constants';
 
 export default function Layout() {
   const location = useLocation();
   const url = location.pathname;
+  const lastUrl: string | undefined = url.split('/').at(-1);
 
   return (
     <>
-      {url === '/recruit-list' && <Header />}
-      {url === '/my-page' && <Header />}
-      {url === '/study-list' && <Header />}
+      {lastUrl && Object.keys(FNB_LIST).includes(lastUrl) && <Header />}
       <main className="md:before:bg-white-gray md:after:bg-white-gray relative mx-auto flex h-screen w-full max-w-3xl flex-col justify-between pt-[52px] md:before:absolute md:before:right-0 md:before:bottom-0 md:before:h-[calc(100%-52px)] md:before:w-[1px] md:before:content-[''] md:after:absolute md:after:bottom-0 md:after:left-0 md:after:h-[calc(100%-52px)] md:after:w-[1px] md:after:content-['']">
         <Outlet key={url} />
       </main>
-      {url === '/recruit-list' && <Fnb nav={'모집'} />}
-      {url === '/study-list' && <Fnb nav={'진행'} />}
-      {url === '/my-page' && <Fnb nav={'마이'} />}
+      {lastUrl && FNB_LIST[lastUrl] && <Fnb nav={FNB_LIST[lastUrl]} />}
     </>
   );
 }

--- a/src/layouts/LoginRequiredLayout.tsx
+++ b/src/layouts/LoginRequiredLayout.tsx
@@ -1,0 +1,23 @@
+import { Outlet, useLocation, useNavigate } from 'react-router-dom';
+import { useAuthStore } from '../store/useAuthStore';
+import { useEffect } from 'react';
+
+export default function LoginRequiredLayout() {
+  const { id } = useAuthStore();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    if (id === -1) {
+      navigate('/login', { replace: true });
+    }
+  }, []);
+
+  return (
+    <>
+      <main className="md:before:bg-white-gray md:after:bg-white-gray relative mx-auto flex h-screen w-full max-w-3xl flex-col justify-between pt-[52px] md:before:absolute md:before:right-0 md:before:bottom-0 md:before:h-[calc(100%-52px)] md:before:w-[1px] md:before:content-[''] md:after:absolute md:after:bottom-0 md:after:left-0 md:after:h-[calc(100%-52px)] md:after:w-[1px] md:after:content-['']">
+        <Outlet key={location.pathname} />
+      </main>
+    </>
+  );
+}

--- a/src/layouts/LoginRequiredLayout.tsx
+++ b/src/layouts/LoginRequiredLayout.tsx
@@ -1,23 +1,9 @@
-import { Outlet, useLocation, useNavigate } from 'react-router-dom';
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
 import { useAuthStore } from '../store/useAuthStore';
-import { useEffect } from 'react';
 
 export default function LoginRequiredLayout() {
   const { id } = useAuthStore();
-  const navigate = useNavigate();
   const location = useLocation();
 
-  useEffect(() => {
-    if (id === -1) {
-      navigate('/login', { replace: true });
-    }
-  }, []);
-
-  return (
-    <>
-      <main className="md:before:bg-white-gray md:after:bg-white-gray relative mx-auto flex h-screen w-full max-w-3xl flex-col justify-between pt-[52px] md:before:absolute md:before:right-0 md:before:bottom-0 md:before:h-[calc(100%-52px)] md:before:w-[1px] md:before:content-[''] md:after:absolute md:after:bottom-0 md:after:left-0 md:after:h-[calc(100%-52px)] md:after:w-[1px] md:after:content-['']">
-        <Outlet key={location.pathname} />
-      </main>
-    </>
-  );
+  return id !== -1 ? <Outlet key={location.pathname} /> : <Navigate to="/login" />;
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,8 +3,6 @@ import App from './App.tsx';
 import './index.css';
 
 async function deferRender() {
-  // if (process.env.NODE_ENV !== 'development') return;
-
   const { worker } = await import('./mocks/browser.ts');
 
   return worker.start({

--- a/src/mocks/kakaoHandlers.ts
+++ b/src/mocks/kakaoHandlers.ts
@@ -1,8 +1,33 @@
 import { http, HttpResponse } from 'msw';
 
 const kakaoHandler = [
-  http.post('/api/kakao-login', ({ params }) => {
-    console.log('kakao 인가 코드 전송', params);
+  http.post('/api/kakao-login', async ({ request }) => {
+    const code = new URL(request.url).searchParams.get('code');
+    console.log('kakao 인가 코드 전송');
+
+    if (code) {
+      return HttpResponse.json({
+        status: 200,
+        data: {
+          id: 1,
+          connected_at: '2025-02-07T06:32:23Z',
+          properties: {
+            nickname: 'seungmani',
+            profile_image: 'https://via.placeholder.com/150',
+            jwt_token: 'token123',
+          },
+        },
+      });
+    } else {
+      return new HttpResponse(
+        JSON.stringify({
+          message: 'kakao 로그인 실패',
+        }),
+        {
+          status: 400,
+        },
+      );
+    }
   }),
 
   http.get('/api/auth/kakao-login', () => {

--- a/src/mocks/kakaoHandlers.ts
+++ b/src/mocks/kakaoHandlers.ts
@@ -44,6 +44,7 @@ const kakaoHandler = [
 
   http.get('/api/auth/kakao-logout', () => {
     console.log('로그아웃');
+    return HttpResponse.json({ message: '로그아웃 성공', status: 200 });
   }),
 
   http.get('/api/auth/login', () => {

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,21 +1,10 @@
 import React from 'react';
 import KaKaoImg from '../assets/imgs/kakao-login-large-wide.png';
-import oauthApi from '../api/oauthApi';
 import HeaderWithBack from '../components/HeaderWithBack';
-import { useAuthStore } from '../store/useAuthStore';
-import { useNavigate } from 'react-router-dom';
-// import { KAKAO_AUTH_URL } from '../constants/oauth';
+import { Link } from 'react-router-dom';
+import { KAKAO_AUTH_URL } from '../constants/oauth';
 
 const Login = React.memo((): JSX.Element => {
-  const navigate = useNavigate();
-  const setAuth = useAuthStore((state) => state.setAuth);
-  const login = async () => {
-    const response = await oauthApi.login();
-    console.log(response);
-    setAuth(response.id, response.properties);
-    navigate('/');
-  };
-
   return (
     <>
       <HeaderWithBack title={'로그인'} />
@@ -27,9 +16,9 @@ const Login = React.memo((): JSX.Element => {
           <br />
           <p>목표를 달성하세요.</p>
         </div>
-        <div onClick={login}>
+        <Link to={KAKAO_AUTH_URL}>
           <img src={KaKaoImg} alt="카카오 로그인 버튼" />
-        </div>
+        </Link>
       </div>
     </>
   );

--- a/src/pages/LoginRedirect.tsx
+++ b/src/pages/LoginRedirect.tsx
@@ -1,0 +1,31 @@
+import { useNavigate } from 'react-router-dom';
+import { useAuthStore } from '../store/useAuthStore';
+import { useEffect } from 'react';
+import oauthApi from '../api/oauthApi';
+
+export default function LoginRedirect() {
+  const navigate = useNavigate();
+  const setAuth = useAuthStore((state) => state.setAuth);
+  const code = new URL(window.location.href).searchParams.get('code');
+
+  useEffect(() => {
+    const kakaoLogin = async () => {
+      console.log('코드 전송', code);
+      const response = await oauthApi.postOauthCode(code);
+      console.log('코드 전송 결과', response);
+      if (response.status === 200) {
+        setAuth(response.data.id, response.data.properties);
+        navigate('/', { replace: true });
+      } else navigate('/login', { replace: true });
+    };
+
+    kakaoLogin();
+  }, [code, navigate, setAuth]);
+
+  return (
+    <>
+      <p>로그인 중입니다.</p>
+      <p>잠시만 기다려주세요.</p>
+    </>
+  );
+}

--- a/src/pages/RecruitList.tsx
+++ b/src/pages/RecruitList.tsx
@@ -28,7 +28,7 @@ export default function RecruitList(): JSX.Element {
           to={'/create-study'}
           className="bg-main flex h-[30px] items-center justify-center rounded-[10px] text-center text-white"
         >
-          <span className="text-sm">'+ 스터디 만들기'</span>
+          <span className="text-sm">+ 스터디 만들기</span>
         </Link>
       )}
     </div>

--- a/src/pages/RecruitList.tsx
+++ b/src/pages/RecruitList.tsx
@@ -23,12 +23,14 @@ export default function RecruitList(): JSX.Element {
         <FilterList />
         <StudyRecruitList />
       </div>
-      <Link
-        to={id !== -1 ? '/create-study' : '/login'}
-        className="bg-main flex h-[30px] items-center justify-center rounded-[10px] text-center text-white"
-      >
-        <span className="text-sm">{id !== -1 ? '+ 스터디 만들기' : '로그인'}</span>
-      </Link>
+      {id !== -1 && (
+        <Link
+          to={'/create-study'}
+          className="bg-main flex h-[30px] items-center justify-center rounded-[10px] text-center text-white"
+        >
+          <span className="text-sm">'+ 스터디 만들기'</span>
+        </Link>
+      )}
     </div>
   );
 }

--- a/src/pages/StudyList.tsx
+++ b/src/pages/StudyList.tsx
@@ -5,7 +5,6 @@ import StudyRoomList from '../components/Study-list/StudyRoomList';
 
 export default function StudyList(): JSX.Element {
   const { filteringInfo } = useSearchStore();
-  const isLogin = true;
 
   return (
     <div className="px-4">
@@ -22,12 +21,6 @@ export default function StudyList(): JSX.Element {
         <FilterList />
         <StudyRoomList />
       </div>
-      <Link
-        to={isLogin ? '/create-study' : '/login'}
-        className="bg-main flex h-[30px] items-center justify-center rounded-[10px] text-center text-white"
-      >
-        <span className="text-sm">{isLogin ? '+ 스터디 만들기' : '로그인'}</span>
-      </Link>
     </div>
   );
 }

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -1,6 +1,7 @@
 import { Routes, Route, Navigate } from 'react-router-dom';
 import { lazy, Suspense } from 'react';
 import Layout from '../layouts/Layout';
+import LoginRequiredLayout from '../layouts/LoginRequiredLayout';
 import LoginRedirect from '../pages/LoginRedirect';
 
 const Login = lazy(() => import('../pages/Login'));
@@ -23,11 +24,14 @@ const Router = (): JSX.Element => {
         <Route element={<Layout />}>
           <Route path="/login" element={<Login />} />
           <Route path="/login/oauth2/callback/kakao" element={<LoginRedirect />} />
-          <Route path="/my-page" element={<MyPage />} />
-          <Route path="/point" element={<Point />} />
           <Route path="/search" element={<Search />} />
 
-          <Route path="/create-study" element={<CreateStudy />} />
+          <Route element={<LoginRequiredLayout />}>
+            <Route path="/my-page" element={<MyPage />} />
+            <Route path="/point" element={<Point />} />
+            <Route path="/create-study" element={<CreateStudy />} />
+            <Route path="/my-study" element={<MyStudyList />} />
+          </Route>
 
           <Route path="/" element={<Navigate to="/recruit-list" replace />} />
           <Route path="/recruit-list" element={<RecruitList />} />
@@ -37,8 +41,6 @@ const Router = (): JSX.Element => {
           <Route path="/study-list" element={<StudyList />} />
           <Route path="/study/:studyId" element={<StudyDetail />} />
           <Route path="/edit-study/:studyId" element={<EditStudy />} />
-
-          <Route path="/my-study" element={<MyStudyList />} />
         </Route>
       </Routes>
     </Suspense>

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -1,6 +1,7 @@
 import { Routes, Route, Navigate } from 'react-router-dom';
 import { lazy, Suspense } from 'react';
 import Layout from '../layouts/Layout';
+import LoginRedirect from '../pages/LoginRedirect';
 
 const Login = lazy(() => import('../pages/Login'));
 const CreateStudy = lazy(() => import('../pages/CreateStudy'));
@@ -21,6 +22,7 @@ const Router = (): JSX.Element => {
       <Routes>
         <Route element={<Layout />}>
           <Route path="/login" element={<Login />} />
+          <Route path="/login/oauth2/callback/kakao" element={<LoginRedirect />} />
           <Route path="/my-page" element={<MyPage />} />
           <Route path="/point" element={<Point />} />
           <Route path="/search" element={<Search />} />


### PR DESCRIPTION
## Background
카카오 로그인 msw 연동 및 로그입 접근 페이지 분리

## Details
- LoginRequiredLayout 생성
<Route path="/my-page" element={<MyPage />} />
<Route path="/point" element={<Point />} />
<Route path="/create-study" element={<CreateStudy />} />
<Route path="/my-study" element={<MyStudyList />} />
위 4개 페이지는 비로그인 시 로그인 페이지로 이동

- 헤더 UI 변경 및 리팩토링
알림 아이콘 제거 후 로그인, 로그아웃 기능 추가
헤더 및 fnb 관련 url 상수로 관리

- kakao 로그인 연동
msw 바인딩으로 code 확인 후 유저 정보 전송

## Discuss

## UI Images
![image](https://github.com/user-attachments/assets/5ef85b7d-6b97-4ae0-b883-1f44f2697e12)
![image](https://github.com/user-attachments/assets/8e5295e5-a1ba-4cfd-9591-ff8fb2915999)

