### PR TITLE
[chore] 배포 과정에서 .env 파일이 자동으로 생성되도록 설정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,11 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v3
 
+      - name: .env setting
+        run: |
+          echo "VITE_SERVER_URL=${{ secrets.SERVER_URL }}" >> .env
+          echo "VITE_KAKAO_API=${{ secrets.KAKAO_API_KEY }}" >> .env
+
       - name: Install dependencies
         run: yarn install
 


### PR DESCRIPTION
## Background
GitHub Secrets를 활용하여 배포 과정에서 .env 파일이 자동으로 생성되도록 설정하였습니다. 이를 통해 보안 문제를 방지하면서도 배포 환경에서 필요한 환경 변수를 주입할 수 있도록 개선하였습니다.


## Details
- GitHub Actions에서 .env 파일을 자동 생성하는 스크립트 추가
- secrets.SERVER_URL, secrets.KAKAO_API_KEY 값을 .env 파일에 주입
- .env 파일이 생성된 후 빌드 및 배포가 정상적으로 진행되도록 설정

