### PR TITLE
[chore] kakao redirect uri 값 배포 env에 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,7 @@ jobs:
         run: |
           echo "VITE_SERVER_URL=${{ secrets.SERVER_URL }}" >> .env
           echo "VITE_KAKAO_API=${{ secrets.KAKAO_API_KEY }}" >> .env
+          echo "VITE_REDIRECT_URL=${{ secrets.KAKAO_REDIRECT_URI}}" >> .env
 
       - name: Install dependencies
         run: yarn install


### PR DESCRIPTION
## Background
배포 사이트에서 카카오 로그인이 안 되는 문제가 발생

## Details
- 기존 deploy.yml에서는 KAKAO_REDIRECT_URI 환경 변수가 누락되어 있어, 배포된 애플리케이션에서 해당 값을 참조할 수 없는 상태였음.
- GitHub Secrets에서 KAKAO_REDIRECT_URI 값을 추가하고, 이를 deploy.yml에서 환경 변수로 설정하도록 수정함.



